### PR TITLE
Separable Rigidbody Grids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +202,12 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arbitrary-chunks"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad8689a486416c401ea15715a4694de30054248ec627edbf31f49cb64ee4086"
 
 [[package]]
 name = "arrayref"
@@ -340,6 +358,43 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "avian3d"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0751cde05c2be789fad86cd19219daf8a8907e0c6c2175f2c8144706493f010"
+dependencies = [
+ "approx",
+ "avian_derive",
+ "bevy",
+ "bevy_heavy",
+ "bevy_math",
+ "bevy_transform_interpolation",
+ "bitflags 2.11.0",
+ "derive_more",
+ "disqualified",
+ "glam_matrix_extras",
+ "itertools 0.14.0",
+ "obvhs",
+ "parry3d",
+ "parry3d-f64",
+ "smallvec",
+ "thiserror 2.0.18",
+ "thread_local",
+]
+
+[[package]]
+name = "avian_derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b257f601a1535e0d4a7a7796f535e3a13de62fd422b16dff7c14d27f0d4048"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "base64"
@@ -857,6 +912,17 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "bevy_heavy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc496d1d43b890896cf561d8ce3dcf7b7b8e4c03c4e837a49a83a530abccbc5e"
+dependencies = [
+ "bevy_math",
+ "bevy_reflect",
+ "glam_matrix_extras",
 ]
 
 [[package]]
@@ -1441,7 +1507,7 @@ dependencies = [
  "crossbeam-queue",
  "derive_more",
  "futures-lite",
- "heapless",
+ "heapless 0.9.2",
  "pin-project",
 ]
 
@@ -1502,6 +1568,15 @@ dependencies = [
  "derive_more",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bevy_transform_interpolation"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88545c8b0fa8f3502b9a439c71fa6b596ee9e808bfb16f27a51c8c6f7405a657"
+dependencies = [
+ "bevy",
 ]
 
 [[package]]
@@ -1730,6 +1805,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-pseudorand"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2097358495d244a0643746f4d13eedba4608137008cf9dec54e53a3b700115a6"
+dependencies = [
+ "chiapos-chacha8",
+ "nanorand",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1978,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chiapos-chacha8"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f8be573a85f6c2bc1b8e43834c07e32f95e489b914bf856c0549c3c269cd0a"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +2002,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2038,31 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -2167,6 +2319,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2588,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encase"
@@ -2785,11 +2982,34 @@ version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 dependencies = [
+ "approx",
  "bytemuck",
  "encase",
  "libm",
  "rand 0.9.2",
  "serde_core",
+]
+
+[[package]]
+name = "glam_matrix_extras"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4664468a60479272b880a8bfc00ad2915229b93d2b2d585556fb33f9ba80e72"
+dependencies = [
+ "bevy_reflect",
+ "glam",
+]
+
+[[package]]
+name = "glamx"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375b4fa374a343fef990a18a6e0413d54bd990c6d7b8c7ada2d3c884275edea3"
+dependencies = [
+ "approx",
+ "glam",
+ "num-traits",
+ "simba",
 ]
 
 [[package]]
@@ -2971,6 +3191,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
  "serde",
@@ -2986,6 +3207,16 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3125,6 +3356,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -3553,6 +3804,12 @@ dependencies = [
  "tracing",
  "unicode-ident",
 ]
+
+[[package]]
+name = "nanorand"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
 
 [[package]]
 name = "ndarray"
@@ -4026,6 +4283,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "obvhs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a714277d5f74beb21a12cb8fb1d4774df5c637c2a0278ff3ebd812f42f7c1e"
+dependencies = [
+ "bytemuck",
+ "glam",
+ "half",
+ "log",
+ "rdst",
+ "static_assertions",
+]
+
+[[package]]
 name = "offset-allocator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,6 +4320,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "orbclient"
@@ -4112,6 +4389,69 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "parry3d"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04d21bda5249438b5695e7f08f1655524a6025bcdb186c324b7a66562f2d61"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.11.0",
+ "downcast-rs 2.0.2",
+ "either",
+ "ena",
+ "foldhash 0.2.0",
+ "glamx",
+ "hashbrown 0.16.1",
+ "log",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "rayon",
+ "rstar",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "static_assertions",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "parry3d-f64"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38558e45fda09a243836f590b9890f7f21dd2078dd7aafc876a9e8998d378d42"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.11.0",
+ "downcast-rs 2.0.2",
+ "either",
+ "ena",
+ "foldhash 0.2.0",
+ "glamx",
+ "hashbrown 0.16.1",
+ "log",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "rayon",
+ "rstar",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "partition"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947f833aaa585cf12b8ec7c0476c98784c49f33b861376ffc84ed92adebf2aba"
 
 [[package]]
 name = "paste"
@@ -4207,6 +4547,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4289,6 +4657,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.11+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4489,6 +4879,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rdst"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7970b4e577b76a96d5e56b5f6662b66d1a4e1f5bb026ee118fc31b373c2752"
+dependencies = [
+ "arbitrary-chunks",
+ "block-pseudorand",
+ "criterion",
+ "partition",
+ "tikv-jemallocator",
+ "voracious_radix_sort",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4582,6 +5006,7 @@ name = "riverbed"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "avian3d",
  "bevy",
  "binary-greedy-meshing",
  "cfg-if 1.0.4",
@@ -4652,6 +5077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rodio"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4680,6 +5111,17 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless 0.8.0",
+ "num-traits",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -4748,6 +5190,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -4885,6 +5336,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste 1.0.15",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5001,6 +5465,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]
@@ -5199,6 +5675,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5221,6 +5717,16 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5509,6 +6015,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "voracious_radix_sort"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446e7ffcb6c27a71d05af7e51ef2ee5b71c48424b122a832f2439651e1914899"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "walkdir"
@@ -5903,6 +6418,16 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 
 [dependencies]
 anyhow = "*"
+avian3d = "0.6"
 bevy = { version = "0.18" }
 binary-greedy-meshing = "*"
 cfg-if = "*"

--- a/src/agents/block_action/block_hit_place.rs
+++ b/src/agents/block_action/block_hit_place.rs
@@ -1,13 +1,16 @@
 use crate::Block;
 use crate::WorldRng;
-use crate::agents::{Action, PlayerControlled, TargetBlock};
+use crate::agents::{
+    Action, PlayerControlled, TargetBlock, TargetKind,
+};
 use crate::items::{
     BlockLootTable, DropQuantity, FiringTable, InventoryTrait, Item, LootEntry, Stack,
 };
 use crate::render::FpsCam;
 use crate::sounds::ItemGet;
 use crate::ui::{CursorGrabbed, GameUiState, ItemHolder, SelectedHotbarSlot};
-use crate::world::{BlockEntities, BlockPos, Realm, VoxelWorld};
+use crate::world::{BlockEntities, BlockPos, GridBlockPos, Realm, VoxelGrid, VoxelWorld};
+use avian3d::prelude::{Collider, SpatialQuery, SpatialQueryFilter};
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 use rand::RngExt;
@@ -60,10 +63,25 @@ pub enum BlockActionType {
     Harvesting,
 }
 
+/// The block a `BlockLootAction` is operating on — used to detect target
+/// changes and to apply the eventual edit.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LootTarget {
+    World(BlockPos),
+    Grid { grid: Entity, pos: GridBlockPos },
+}
+
+/// The block a per-block side-effect entity (currently `Renewable`) is bound to.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AttachedBlock {
+    World(BlockPos),
+    Grid { grid: Entity, pos: GridBlockPos },
+}
+
 #[derive(Component)]
 #[component(storage = "SparseSet")]
 pub struct BlockLootAction {
-    pub block_pos: BlockPos,
+    pub target: LootTarget,
     pub block: Block,
     pub action_type: BlockActionType,
     pub time_left: f32,
@@ -85,7 +103,7 @@ const EDGES_LINES: [Vec3; 4] = [
 ];
 
 #[derive(Component)]
-pub struct BlockAttached(BlockPos);
+pub struct BlockAttached(pub AttachedBlock);
 
 #[derive(Component)]
 pub struct Renewable {
@@ -93,20 +111,90 @@ pub struct Renewable {
     renew_after: Instant,
 }
 
+/// Camera-forward raycast: takes the closer of the world's DDA-based hit and
+/// Avian's physics raycast (used for movable grids). Only colliders that
+/// belong to a `VoxelGrid` ancestor are accepted from the physics side, so
+/// world-chunk colliders don't double-up against the DDA result.
 fn target_block(
-    mut player: Query<(&mut TargetBlock, &Realm), With<PlayerControlled>>,
+    mut player: Query<(Entity, &mut TargetBlock, &Realm), With<PlayerControlled>>,
     player_cam: Query<&GlobalTransform, With<FpsCam>>,
     world: Res<VoxelWorld>,
+    spatial_query: SpatialQuery,
+    grids: Query<(Entity, &GlobalTransform, &VoxelGrid)>,
+    parents: Query<&ChildOf>,
 ) {
-    let (mut target_block, realm) = player.single_mut().unwrap();
-    let transform = player_cam.single().unwrap();
-    target_block.0 = world.raycast(
-        *realm,
-        transform.translation(),
-        *transform.forward(),
-        TARGET_DIST,
-        true,
-    );
+    let (player_entity, mut target_block, realm) = player.single_mut().unwrap();
+    let cam = player_cam.single().unwrap();
+    let origin = cam.translation();
+    let dir = *cam.forward();
+
+    let world_hit = world.raycast(*realm, origin, dir, TARGET_DIST, true);
+    let world_dist = world_hit
+        .as_ref()
+        .map(|hit| approx_block_distance(hit.pos, origin));
+
+    let grid_hit = (|| -> Option<TargetKind> {
+        let dir3 = Dir3::new(dir).ok()?;
+        let filter = SpatialQueryFilter::default().with_excluded_entities([player_entity]);
+        let hit = spatial_query.cast_ray(origin, dir3, TARGET_DIST, true, &filter)?;
+        let (grid_entity, grid_xform) = find_grid_ancestor(hit.entity, &grids, &parents)?;
+        // Reject if a world-chunk collider sits in front of the grid hit.
+        if let Some(wd) = world_dist {
+            if wd < hit.distance {
+                return None;
+            }
+        }
+        let world_point = origin + dir * hit.distance;
+        let world_inside = world_point - hit.normal * 0.01;
+        let grid_inverse = grid_xform.affine().inverse();
+        let local = grid_inverse.transform_point3(world_inside);
+        let pos = GridBlockPos {
+            x: local.x.floor() as i32,
+            y: local.y.floor() as i32,
+            z: local.z.floor() as i32,
+        };
+        let normal_local = axis_aligned(grid_inverse.transform_vector3(hit.normal));
+        Some(TargetKind::Grid {
+            grid: grid_entity,
+            pos,
+            normal_local,
+        })
+    })();
+
+    target_block.0 = grid_hit.or_else(|| world_hit.map(TargetKind::World));
+}
+
+fn approx_block_distance(pos: BlockPos, origin: Vec3) -> f32 {
+    let center = Vec3::new(pos.x as f32, pos.y as f32, pos.z as f32) + Vec3::splat(0.5);
+    (center - origin).length()
+}
+
+/// Snap a (near-axis-aligned) vector to the closest unit cardinal axis. Used
+/// to convert a trimesh-face hit normal into a block-face normal suitable for
+/// `+pos` placement offsets.
+fn axis_aligned(v: Vec3) -> Vec3 {
+    let abs = v.abs();
+    if abs.x >= abs.y && abs.x >= abs.z {
+        Vec3::new(v.x.signum(), 0., 0.)
+    } else if abs.y >= abs.z {
+        Vec3::new(0., v.y.signum(), 0.)
+    } else {
+        Vec3::new(0., 0., v.z.signum())
+    }
+}
+
+fn find_grid_ancestor(
+    mut entity: Entity,
+    grids: &Query<(Entity, &GlobalTransform, &VoxelGrid)>,
+    parents: &Query<&ChildOf>,
+) -> Option<(Entity, GlobalTransform)> {
+    loop {
+        if let Ok((e, xform, _)) = grids.get(entity) {
+            return Some((e, *xform));
+        }
+        let child_of = parents.get(entity).ok()?;
+        entity = child_of.parent();
+    }
 }
 
 fn target_block_changed(
@@ -117,31 +205,68 @@ fn target_block_changed(
     >,
 ) {
     for (player, break_action, target_block_opt) in target_query.iter() {
-        if target_block_opt.0.is_none()
-            || break_action.block_pos != target_block_opt.0.as_ref().unwrap().pos
-        {
+        let still_valid = match (&target_block_opt.0, &break_action.target) {
+            (Some(TargetKind::World(hit)), LootTarget::World(pos)) => hit.pos == *pos,
+            (Some(TargetKind::Grid { grid: g1, pos: p1, .. }), LootTarget::Grid { grid: g2, pos: p2 }) => {
+                g1 == g2 && p1 == p2
+            }
+            _ => false,
+        };
+        if !still_valid {
             commands.entity(player).remove::<BlockLootAction>();
         }
     }
 }
 
-fn block_outline(mut gizmos: Gizmos, target_block_query: Query<&TargetBlock>) {
+fn block_outline(
+    mut gizmos: Gizmos,
+    target_block_query: Query<&TargetBlock>,
+    grids: Query<&GlobalTransform, With<VoxelGrid>>,
+) {
     for target_block_opt in target_block_query.iter() {
-        if let Some(target_block) = &target_block_opt.0 {
-            let pos: Vec3 = target_block.pos.into();
-            for (anchor, lines) in zip(EDGES_ANCHORS, EDGES_LINES) {
-                let anchor_pos = pos + anchor;
-                gizmos.line(anchor_pos, anchor_pos + lines * Vec3::X, Color::BLACK);
-                gizmos.line(anchor_pos, anchor_pos + lines * Vec3::Y, Color::BLACK);
-                gizmos.line(anchor_pos, anchor_pos + lines * Vec3::Z, Color::BLACK);
+        match &target_block_opt.0 {
+            Some(TargetKind::World(hit)) => {
+                let pos: Vec3 = hit.pos.into();
+                draw_block_outline(&mut gizmos, pos, Quat::IDENTITY);
             }
+            Some(TargetKind::Grid { grid, pos, .. }) => {
+                let Ok(xform) = grids.get(*grid) else {
+                    continue;
+                };
+                let local = Vec3::new(pos.x as f32, pos.y as f32, pos.z as f32);
+                let (_, rot, _) = xform.to_scale_rotation_translation();
+                draw_block_outline(&mut gizmos, xform.transform_point(local), rot);
+            }
+            None => {}
         }
+    }
+}
+
+fn draw_block_outline(gizmos: &mut Gizmos, origin: Vec3, rotation: Quat) {
+    for (anchor, lines) in zip(EDGES_ANCHORS, EDGES_LINES) {
+        let anchor_pos = origin + rotation * anchor;
+        gizmos.line(
+            anchor_pos,
+            anchor_pos + rotation * (lines * Vec3::X),
+            Color::BLACK,
+        );
+        gizmos.line(
+            anchor_pos,
+            anchor_pos + rotation * (lines * Vec3::Y),
+            Color::BLACK,
+        );
+        gizmos.line(
+            anchor_pos,
+            anchor_pos + rotation * (lines * Vec3::Z),
+            Color::BLACK,
+        );
     }
 }
 
 fn break_action(
     mut commands: Commands,
     world: Res<VoxelWorld>,
+    grids: Query<&VoxelGrid>,
     mut block_action_query: Query<(
         Entity,
         &TargetBlock,
@@ -155,12 +280,12 @@ fn break_action(
     time: Res<Time>,
     mut col_entities: ResMut<BlockEntities>,
     mut world_rng: ResMut<WorldRng>,
-    block_entt_query: Query<&BlockAttached>,
+    block_entt_query: Query<(Entity, &BlockAttached)>,
 ) {
     for (player, target_block_opt, mut hotbar, action, opt_looting) in block_action_query.iter_mut()
     {
         let Some(mut looting) = opt_looting else {
-            // No current looting action, we add one
+            // No current looting action — try to start one
             let action_type = if action.pressed(&Action::Hit) {
                 BlockActionType::Breaking
             } else if action.pressed(&Action::Modify) {
@@ -168,10 +293,22 @@ fn break_action(
             } else {
                 continue;
             };
-            let Some(target_block) = &target_block_opt.0 else {
+            let Some(target) = &target_block_opt.0 else {
                 continue;
             };
-            let block = world.get_block(target_block.pos);
+            let (block, loot_target) = match target {
+                TargetKind::World(hit) => (world.get_block(hit.pos), LootTarget::World(hit.pos)),
+                TargetKind::Grid { grid, pos, .. } => {
+                    let Ok(g) = grids.get(*grid) else { continue };
+                    (
+                        g.get_block(*pos),
+                        LootTarget::Grid {
+                            grid: *grid,
+                            pos: *pos,
+                        },
+                    )
+                }
+            };
             if !block.is_targetable() {
                 continue;
             }
@@ -184,7 +321,7 @@ fn break_action(
                 continue;
             };
             commands.entity(player).insert(BlockLootAction {
-                block_pos: target_block.pos,
+                target: loot_target,
                 block,
                 action_type,
                 time_left: hardness,
@@ -192,7 +329,7 @@ fn break_action(
             });
             continue;
         };
-        // There's a block action
+        // There's an existing action — count it down
         if !action.pressed(&match looting.action_type {
             BlockActionType::Breaking => Action::Hit,
             BlockActionType::Harvesting => Action::Modify,
@@ -204,23 +341,40 @@ fn break_action(
         if looting.time_left > 0. {
             continue;
         }
-        let Some(target_block) = &target_block_opt.0 else {
-            continue;
-        };
-        match looting.action_type {
-            BlockActionType::Breaking => {
-                world.set_block(target_block.pos, Block::Air);
-                if let Some(entity) = col_entities.get(&target_block.pos) {
-                    if let Ok(block_pos) = block_entt_query.get(entity) {
-                        if block_pos.0 == target_block.pos {
+        // Action completed — apply the edit
+        match (&looting.action_type, &looting.target) {
+            (BlockActionType::Breaking, LootTarget::World(pos)) => {
+                world.set_block(*pos, Block::Air);
+                if let Some(entity) = col_entities.get(pos) {
+                    if let Ok((_, attached)) = block_entt_query.get(entity) {
+                        if matches!(attached.0, AttachedBlock::World(p) if p == *pos) {
                             commands.entity(entity).despawn();
                         }
                     }
                 }
             }
-            BlockActionType::Harvesting => {
-                let depleted = world.get_block(target_block.pos).depleted();
-                world.set_block(target_block.pos, depleted);
+            (BlockActionType::Breaking, LootTarget::Grid { grid, pos }) => {
+                if let Ok(g) = grids.get(*grid) {
+                    g.set_block(*pos, Block::Air);
+                }
+                // Despawn any side-effect entity (e.g. a pending renewable
+                // timer) tied to this grid block. World blocks use the
+                // `BlockEntities` map; grids iterate since few exist.
+                for (entity, attached) in block_entt_query.iter() {
+                    if let AttachedBlock::Grid {
+                        grid: g2,
+                        pos: p2,
+                    } = attached.0
+                    {
+                        if g2 == *grid && p2 == *pos {
+                            commands.entity(entity).despawn();
+                        }
+                    }
+                }
+            }
+            (BlockActionType::Harvesting, LootTarget::World(pos)) => {
+                let depleted = world.get_block(*pos).depleted();
+                world.set_block(*pos, depleted);
                 if let Some(renewal_minutes) = depleted.renewal_minutes() {
                     let renew_entt = commands
                         .spawn((
@@ -229,10 +383,29 @@ fn break_action(
                                     .checked_add(Duration::from_secs(renewal_minutes as u64))
                                     .unwrap(),
                             },
-                            BlockAttached(target_block.pos),
+                            BlockAttached(AttachedBlock::World(*pos)),
                         ))
                         .id();
-                    col_entities.add(&target_block.pos, renew_entt);
+                    col_entities.add(pos, renew_entt);
+                }
+            }
+            (BlockActionType::Harvesting, LootTarget::Grid { grid, pos }) => {
+                if let Ok(g) = grids.get(*grid) {
+                    let depleted = g.get_block(*pos).depleted();
+                    g.set_block(*pos, depleted);
+                    if let Some(renewal_minutes) = depleted.renewal_minutes() {
+                        commands.spawn((
+                            Renewable {
+                                renew_after: Instant::now()
+                                    .checked_add(Duration::from_secs(renewal_minutes as u64))
+                                    .unwrap(),
+                            },
+                            BlockAttached(AttachedBlock::Grid {
+                                grid: *grid,
+                                pos: *pos,
+                            }),
+                        ));
+                    }
                 }
             }
         }
@@ -266,20 +439,24 @@ pub struct BlockPlaced(pub BlockPos);
 fn place_block(
     mut commands: Commands,
     world: Res<VoxelWorld>,
-    mut block_action_query: Query<(&TargetBlock, &mut ItemHolder, &ActionState<Action>)>,
+    grids: Query<&VoxelGrid>,
+    grid_xforms: Query<(Entity, &GlobalTransform, &VoxelGrid)>,
+    mut block_action_query: Query<(
+        Entity,
+        &TargetBlock,
+        &mut ItemHolder,
+        &ActionState<Action>,
+    )>,
     selected_slot: Res<SelectedHotbarSlot>,
+    spatial_query: SpatialQuery,
 ) {
-    for (target_block_opt, mut hotbar, action) in block_action_query.iter_mut() {
+    for (player_entity, target_block_opt, mut hotbar, action) in block_action_query.iter_mut() {
         if !action.just_pressed(&Action::Modify) {
             continue;
         }
-        let Some(target_block) = &target_block_opt.0 else {
+        let Some(target) = &target_block_opt.0 else {
             continue;
         };
-        let pos = target_block.pos + target_block.normal;
-        if world.get_block(pos).is_targetable() {
-            continue;
-        }
         let block = match hotbar.get_mut(selected_slot.0).take(1) {
             Stack::Some(Item::Block(block), _) => block,
             other => {
@@ -287,27 +464,116 @@ fn place_block(
                 continue;
             }
         };
-        if !world.set_block_safe(pos, block) {
-            // If the block couldn't be added we add it back
+        let placed = match target {
+            TargetKind::World(hit) => {
+                let pos = hit.pos + hit.normal;
+                if !world.get_block(pos).is_traversable() {
+                    false
+                } else {
+                    let center =
+                        Vec3::new(pos.x as f32, pos.y as f32, pos.z as f32) + Vec3::splat(0.5);
+                    if placement_overlaps(
+                        &spatial_query,
+                        center,
+                        Quat::IDENTITY,
+                        &[player_entity],
+                    ) {
+                        false
+                    } else if world.set_block_safe(pos, block) {
+                        commands.trigger(BlockPlaced(pos));
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+            TargetKind::Grid {
+                grid,
+                pos,
+                normal_local,
+                ..
+            } => {
+                let Ok(g) = grids.get(*grid) else { continue };
+                let new_pos = GridBlockPos {
+                    x: pos.x + normal_local.x as i32,
+                    y: pos.y + normal_local.y as i32,
+                    z: pos.z + normal_local.z as i32,
+                };
+                if !g.get_block(new_pos).is_traversable() {
+                    false
+                } else {
+                    let Ok((_, grid_xform, _)) = grid_xforms.get(*grid) else {
+                        continue;
+                    };
+                    let (_, rotation, _) = grid_xform.to_scale_rotation_translation();
+                    let center = grid_xform.transform_point(
+                        Vec3::new(new_pos.x as f32, new_pos.y as f32, new_pos.z as f32)
+                            + Vec3::splat(0.5),
+                    );
+                    if placement_overlaps(
+                        &spatial_query,
+                        center,
+                        rotation,
+                        &[player_entity],
+                    ) {
+                        false
+                    } else {
+                        g.set_block(new_pos, block);
+                        true
+                    }
+                }
+            }
+        };
+        if !placed {
             hotbar
                 .get_mut(selected_slot.0)
                 .try_add(Stack::Some(Item::Block(block), 1));
-        } else {
-            commands.trigger(BlockPlaced(pos));
         }
     }
+}
+
+/// True if a 1m³ block at `(center, rotation)` would overlap an existing
+/// collider. The probe is 0.95m so neighbouring blocks (whose trimesh faces
+/// sit on the placement cell's boundaries) don't false-positive as touching
+/// contacts; rotated grids exceed that 0.025m clearance whenever they
+/// genuinely overlap.
+fn placement_overlaps(
+    spatial_query: &SpatialQuery,
+    center: Vec3,
+    rotation: Quat,
+    excluded: &[Entity],
+) -> bool {
+    let probe = Collider::cuboid(0.95, 0.95, 0.95);
+    let filter =
+        SpatialQueryFilter::default().with_excluded_entities(excluded.iter().copied());
+    !spatial_query
+        .shape_intersections(&probe, center, rotation, &filter)
+        .is_empty()
 }
 
 fn renew_block(
     mut commands: Commands,
     world: Res<VoxelWorld>,
+    grids: Query<&VoxelGrid>,
     renewables: Query<(Entity, &Renewable, &BlockAttached)>,
 ) {
     let now = Instant::now();
-    for (entity, renewable, pos) in renewables.iter() {
-        if now >= renewable.renew_after {
-            world.set_block(pos.0, world.get_block(pos.0).renewed());
-            commands.entity(entity).despawn();
+    for (entity, renewable, attached) in renewables.iter() {
+        if now < renewable.renew_after {
+            continue;
         }
+        match attached.0 {
+            AttachedBlock::World(pos) => {
+                world.set_block(pos, world.get_block(pos).renewed());
+            }
+            AttachedBlock::Grid { grid, pos } => {
+                // If the grid was despawned, the renewable is silently
+                // dropped when we despawn its entity below.
+                if let Ok(g) = grids.get(grid) {
+                    g.set_block(pos, g.get_block(pos).renewed());
+                }
+            }
+        }
+        commands.entity(entity).despawn();
     }
 }

--- a/src/agents/block_action/block_hit_place.rs
+++ b/src/agents/block_action/block_hit_place.rs
@@ -40,6 +40,7 @@ impl Plugin for BlockHitPlacePlugin {
             )
             .unwrap(),
         )
+        .add_message::<BlockDestroyed>()
         .add_systems(
             Update,
             (break_action, target_block, target_block_changed)
@@ -281,6 +282,7 @@ fn break_action(
     mut col_entities: ResMut<BlockEntities>,
     mut world_rng: ResMut<WorldRng>,
     block_entt_query: Query<(Entity, &BlockAttached)>,
+    mut destroyed_writer: MessageWriter<BlockDestroyed>,
 ) {
     for (player, target_block_opt, mut hotbar, action, opt_looting) in block_action_query.iter_mut()
     {
@@ -352,6 +354,7 @@ fn break_action(
                         }
                     }
                 }
+                destroyed_writer.write(BlockDestroyed::World(*pos));
             }
             (BlockActionType::Breaking, LootTarget::Grid { grid, pos }) => {
                 if let Ok(g) = grids.get(*grid) {
@@ -371,6 +374,10 @@ fn break_action(
                         }
                     }
                 }
+                destroyed_writer.write(BlockDestroyed::Grid {
+                    grid: *grid,
+                    pos: *pos,
+                });
             }
             (BlockActionType::Harvesting, LootTarget::World(pos)) => {
                 let depleted = world.get_block(*pos).depleted();
@@ -435,6 +442,15 @@ fn break_action(
 
 #[derive(Event)]
 pub struct BlockPlaced(pub BlockPos);
+
+/// Fired whenever a solid block becomes Air via player action — used by the
+/// disconnected-component detector to decide when to split a piece off into
+/// its own movable grid.
+#[derive(Message)]
+pub enum BlockDestroyed {
+    World(BlockPos),
+    Grid { grid: Entity, pos: GridBlockPos },
+}
 
 fn place_block(
     mut commands: Commands,

--- a/src/agents/block_action/furnace_action.rs
+++ b/src/agents/block_action/furnace_action.rs
@@ -1,5 +1,5 @@
 use crate::{
-    agents::{Action, PlayerControlled, TargetBlock},
+    agents::{Action, PlayerControlled, TargetBlock, TargetKind},
     items::{FiringTable, LitFurnace, Stack},
     ui::{furnace_slots, GameUiState, ItemHolder, OpenFurnace},
     world::{BlockEntities, BlockPos, VoxelWorld},
@@ -48,14 +48,16 @@ fn open_furnace_menu(
         if !action.just_pressed(&Action::Modify) {
             continue;
         }
-        let Some(target_block) = &target_block_opt.0 else {
+        // Furnaces exist only in the static world; ignore grid targets.
+        let Some(TargetKind::World(hit)) = &target_block_opt.0 else {
             continue;
         };
-        let furnace = world.get_block(target_block.pos);
+        let block_pos = hit.pos;
+        let furnace = world.get_block(block_pos);
         let Some(furnace_temp) = furnace.furnace_temp() else {
             continue;
         };
-        let furnace_ent = if let Some(ent) = block_entities.get(&target_block.pos) {
+        let furnace_ent = if let Some(ent) = block_entities.get(&block_pos) {
             if furnace_query.contains(ent) {
                 ent
             } else {
@@ -64,11 +66,11 @@ fn open_furnace_menu(
                     .insert(Furnace {
                         name: furnace.to_string(),
                         temp: furnace_temp,
-                        block_pos: target_block.pos,
+                        block_pos,
                     })
                     .insert(furnace_slots())
                     .id();
-                block_entities.add(&target_block.pos, ent);
+                block_entities.add(&block_pos, ent);
                 ent
             }
         } else {
@@ -76,11 +78,11 @@ fn open_furnace_menu(
                 .spawn(Furnace {
                     name: furnace.to_string(),
                     temp: furnace_temp,
-                    block_pos: target_block.pos,
+                    block_pos,
                 })
                 .insert(furnace_slots())
                 .id();
-            block_entities.add(&target_block.pos, ent);
+            block_entities.add(&block_pos, ent);
             ent
         };
         furnace_menu.0 = Some(furnace_ent);

--- a/src/agents/block_action/mod.rs
+++ b/src/agents/block_action/mod.rs
@@ -1,20 +1,19 @@
 mod block_hit_place;
 mod furnace_action;
+mod split;
 pub use furnace_action::*;
 pub use block_hit_place::*;
 use bevy::prelude::*;
 use block_hit_place::BlockHitPlacePlugin;
 use furnace_action::FurnaceActionPlugin;
+use split::{SplitChannel, apply_split_outputs, schedule_split_jobs};
 
 pub struct BlockActionPlugin;
 
 impl Plugin for BlockActionPlugin {
     fn build(&self, app: &mut App) {
-        app
-            .add_plugins((
-                BlockHitPlacePlugin,
-                FurnaceActionPlugin
-            ))
-        ;
+        app.add_plugins((BlockHitPlacePlugin, FurnaceActionPlugin))
+            .init_resource::<SplitChannel>()
+            .add_systems(Update, (schedule_split_jobs, apply_split_outputs).chain());
     }
 }

--- a/src/agents/block_action/split.rs
+++ b/src/agents/block_action/split.rs
@@ -1,0 +1,558 @@
+use crate::Block;
+use crate::agents::block_action::BlockDestroyed;
+use crate::render::{ChunkColliderEntities, GridChildEntities, TextureMap, spawn_voxel_grid};
+use crate::world::{
+    BlockPos, Chunk, ChunkPos, ChunkedPos, GridBlockPos, GridChunkPos, Realm, VoxelGrid, VoxelWorld,
+};
+use avian3d::prelude::{AngularVelocity, Collider, LinearVelocity};
+use bevy::prelude::*;
+use crossbeam::channel::{Receiver, Sender, unbounded};
+use crossbeam_skiplist::SkipMap;
+use parking_lot::RwLock;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+use std::thread;
+
+/// Maximum surface cells visited across all seeds in the connectivity BFS.
+/// Surface-only expansion means this caps the total *boundary* of the
+/// candidate component; the actual block count of a splittable piece can be
+/// much higher (a 20³ solid is ~2400 surface cells).
+const SPLIT_BFS_BUDGET: usize = 4096;
+
+/// Cap on the dense flood-fill that collects interior cells once a split has
+/// been confirmed. Surface BFS only touches the manifold; interior cells are
+/// reached via this pass.
+const FILL_COMPONENT_BUDGET: usize = 65536;
+
+
+/// Resource shared between the BFS spawner and applier — async tasks send
+/// completed split outputs here for the main thread to consume.
+#[derive(Resource)]
+pub struct SplitChannel {
+    sender: Sender<SplitOutput>,
+    receiver: Receiver<SplitOutput>,
+}
+
+impl Default for SplitChannel {
+    fn default() -> Self {
+        let (sender, receiver) = unbounded();
+        Self { sender, receiver }
+    }
+}
+
+enum SplitOutput {
+    World {
+        positions: HashSet<(i32, i32, i32)>,
+        realm: Realm,
+    },
+    Grid {
+        source: Entity,
+        transform: Transform,
+        linear_velocity: LinearVelocity,
+        angular_velocity: AngularVelocity,
+        positions: HashSet<(i32, i32, i32)>,
+    },
+}
+
+/// Per-frame system: turns each `BlockDestroyed` event into a BFS job on a
+/// fresh OS thread. We use `std::thread::spawn` rather than Bevy's
+/// `AsyncComputeTaskPool` because the BFS body is CPU-bound with no `.await`
+/// points and would otherwise contend with the chunk mesh worker (which
+/// blocks on a channel `recv` inside its own pool task) for the pool's
+/// limited threads, looking like a freeze when both run at once.
+pub fn schedule_split_jobs(
+    mut events: MessageReader<BlockDestroyed>,
+    world: Res<VoxelWorld>,
+    grids: Query<(
+        &GlobalTransform,
+        &VoxelGrid,
+        Option<&LinearVelocity>,
+        Option<&AngularVelocity>,
+    )>,
+    channel: Res<SplitChannel>,
+) {
+    for event in events.read() {
+        match event {
+            BlockDestroyed::World(pos) => {
+                let chunks = world.chunks.clone();
+                let realm = pos.realm;
+                let dest = (pos.x, pos.y, pos.z);
+                let sender = channel.sender.clone();
+                thread::spawn(move || {
+                    let reader = WorldReader { chunks, realm };
+                    if let Some(positions) = run_split_bfs(&reader, dest) {
+                        let _ = sender.send(SplitOutput::World { positions, realm });
+                    }
+                });
+            }
+            BlockDestroyed::Grid { grid, pos } => {
+                let Ok((xform, g, lin, ang)) = grids.get(*grid) else {
+                    continue;
+                };
+                let chunks = g.chunks.clone();
+                let dest = (pos.x, pos.y, pos.z);
+                let source = *grid;
+                let transform = xform.compute_transform();
+                let linear_velocity = lin.copied().unwrap_or_default();
+                let angular_velocity = ang.copied().unwrap_or_default();
+                let sender = channel.sender.clone();
+                thread::spawn(move || {
+                    let reader = GridReader { chunks };
+                    if let Some(positions) = run_split_bfs(&reader, dest) {
+                        let _ = sender.send(SplitOutput::Grid {
+                            source,
+                            transform,
+                            linear_velocity,
+                            angular_velocity,
+                            positions,
+                        });
+                    }
+                });
+            }
+        }
+    }
+}
+
+/// Drains finished split tasks and applies their results on the main thread.
+/// Re-verifies that every block in the proposed component is still solid —
+/// the player or another split may have changed the world between the BFS
+/// snapshot and the apply, and we don't want to clone air blocks into a grid.
+pub fn apply_split_outputs(
+    mut commands: Commands,
+    channel: Res<SplitChannel>,
+    world: Res<VoxelWorld>,
+    mut grid_data: Query<(&VoxelGrid, &mut GridChildEntities)>,
+    mut world_collider_ents: ResMut<ChunkColliderEntities>,
+    texture_map: Res<TextureMap>,
+) {
+    while let Ok(output) = channel.receiver.try_recv() {
+        match output {
+            SplitOutput::World { positions, realm } => {
+                let valid: Vec<(BlockPos, Block)> = positions
+                    .iter()
+                    .map(|&(x, y, z)| BlockPos { x, y, z, realm })
+                    .filter_map(|p| {
+                        let b = world.get_block(p);
+                        (!b.is_traversable()).then_some((p, b))
+                    })
+                    .collect();
+                if valid.is_empty() {
+                    continue;
+                }
+                for (p, _) in &valid {
+                    world.set_block(*p, Block::Air);
+                }
+                rebuild_world_chunk_colliders(
+                    &mut commands,
+                    &world,
+                    &mut world_collider_ents,
+                    valid.iter().map(|(p, _)| *p),
+                );
+                // Anchor at the bounding-box minimum so block coords end up
+                // non-negative; for any component fitting in CHUNK_S1 cells
+                // along each axis this lands the whole piece in one grid
+                // chunk, giving Parry a closed-manifold trimesh per child.
+                let min_x = valid.iter().map(|(p, _)| p.x).min().unwrap();
+                let min_y = valid.iter().map(|(p, _)| p.y).min().unwrap();
+                let min_z = valid.iter().map(|(p, _)| p.z).min().unwrap();
+                let anchor = Transform::from_xyz(min_x as f32, min_y as f32, min_z as f32);
+                spawn_voxel_grid(&mut commands, &texture_map, anchor, |grid| {
+                    for (p, block) in valid {
+                        grid.set_block(
+                            GridBlockPos {
+                                x: p.x - min_x,
+                                y: p.y - min_y,
+                                z: p.z - min_z,
+                            },
+                            block,
+                        );
+                    }
+                });
+            }
+            SplitOutput::Grid {
+                source,
+                transform,
+                linear_velocity,
+                angular_velocity,
+                positions,
+            } => {
+                let Ok((g, mut tracker)) = grid_data.get_mut(source) else {
+                    continue;
+                };
+                let valid: Vec<(GridBlockPos, Block)> = positions
+                    .iter()
+                    .map(|&(x, y, z)| GridBlockPos { x, y, z })
+                    .filter_map(|p| {
+                        let b = g.get_block(p);
+                        (!b.is_traversable()).then_some((p, b))
+                    })
+                    .collect();
+                if valid.is_empty() {
+                    continue;
+                }
+                for (p, _) in &valid {
+                    g.set_block(*p, Block::Air);
+                }
+                rebuild_grid_chunk_colliders(
+                    &mut commands,
+                    g,
+                    &mut tracker,
+                    valid.iter().map(|(p, _)| *p),
+                );
+                if tracker.collider.is_empty() {
+                    commands.entity(source).despawn();
+                }
+                let new_entity =
+                    spawn_voxel_grid(&mut commands, &texture_map, transform, |grid| {
+                        for (p, block) in valid {
+                            grid.set_block(p, block);
+                        }
+                    });
+                commands
+                    .entity(new_entity)
+                    .insert((linear_velocity, angular_velocity));
+            }
+        }
+    }
+}
+
+/// Rebuilds the trimesh collider for every world chunk that lost a block in
+/// this split. Without this, the world's static collider still claims the
+/// space the new dynamic grid is about to occupy, and Avian sees deeply-
+/// penetrating dynamic-vs-static contacts on every cell of the split → solver
+/// stalls. The async mesh worker would update these eventually, but not
+/// before the next physics step.
+fn rebuild_world_chunk_colliders(
+    commands: &mut Commands,
+    world: &VoxelWorld,
+    collider_ents: &mut ChunkColliderEntities,
+    blocks: impl IntoIterator<Item = BlockPos>,
+) {
+    let affected: HashSet<ChunkPos> = blocks
+        .into_iter()
+        .map(|p| <(ChunkPos, ChunkedPos)>::from(p).0)
+        .collect();
+    for chunk_pos in affected {
+        let Some(entry) = world.chunks.get(&chunk_pos) else {
+            continue;
+        };
+        let new_collider = entry
+            .value()
+            .read()
+            .create_collider_data()
+            .map(|(v, i)| Collider::trimesh(v, i));
+        match (collider_ents.0.get(&chunk_pos).copied(), new_collider) {
+            (Some(ent), Some(c)) => {
+                commands.entity(ent).insert(c);
+            }
+            (Some(ent), None) => {
+                commands.entity(ent).despawn();
+                collider_ents.0.remove(&chunk_pos);
+            }
+            (None, _) => {
+                // No existing collider entity to update — chunk had no surface
+                // before the split (unusual). The async worker will spawn one
+                // if the new state warrants it.
+            }
+        }
+    }
+}
+
+/// Source-grid analogue of `rebuild_world_chunk_colliders`. Without this, the
+/// source's existing per-chunk colliders overlap the new grid 1:1 in world
+/// space until the async worker catches up.
+fn rebuild_grid_chunk_colliders(
+    commands: &mut Commands,
+    grid: &VoxelGrid,
+    tracker: &mut GridChildEntities,
+    blocks: impl IntoIterator<Item = GridBlockPos>,
+) {
+    let affected: HashSet<GridChunkPos> = blocks
+        .into_iter()
+        .map(|p| <(GridChunkPos, ChunkedPos)>::from(p).0)
+        .collect();
+    for chunk_pos in affected {
+        let Some(entry) = grid.chunks.get(&chunk_pos) else {
+            continue;
+        };
+        let new_collider = entry
+            .value()
+            .read()
+            .create_collider_data()
+            .map(|(v, i)| Collider::trimesh(v, i));
+        match (tracker.collider.get(&chunk_pos).copied(), new_collider) {
+            (Some(ent), Some(c)) => {
+                commands.entity(ent).insert(c);
+            }
+            (Some(ent), None) => {
+                commands.entity(ent).despawn();
+                tracker.collider.remove(&chunk_pos);
+            }
+            (None, _) => {}
+        }
+    }
+}
+
+/// Reads voxel data through an Arc-cloneable storage handle so the BFS can
+/// run on a worker thread without the main `VoxelWorld` / `VoxelGrid`
+/// resources.
+///
+/// `solidity` returns `Some(true)` for a known-solid cell, `Some(false)` for a
+/// known-air cell, and `None` if the cell is *unknown* — this only happens
+/// for the world, where chunks load lazily and unloaded chunks could contain
+/// either solid or air. Encountering `None` aborts the BFS, because we can't
+/// rule out that a "bounded" component actually extends into an unloaded
+/// chunk and is still connected to the rest of the terrain.
+trait VoxelReader: Send + Sync {
+    fn solidity(&self, p: (i32, i32, i32)) -> Option<bool>;
+}
+
+struct WorldReader {
+    chunks: Arc<SkipMap<ChunkPos, RwLock<Chunk>>>,
+    realm: Realm,
+}
+
+impl VoxelReader for WorldReader {
+    fn solidity(&self, p: (i32, i32, i32)) -> Option<bool> {
+        let (chunk_pos, chunked_pos) = <(ChunkPos, ChunkedPos)>::from(BlockPos {
+            x: p.0,
+            y: p.1,
+            z: p.2,
+            realm: self.realm,
+        });
+        let entry = self.chunks.get(&chunk_pos)?;
+        Some(!entry.value().read().get(chunked_pos).is_traversable())
+    }
+}
+
+struct GridReader {
+    chunks: Arc<SkipMap<GridChunkPos, RwLock<Chunk>>>,
+}
+
+impl VoxelReader for GridReader {
+    fn solidity(&self, p: (i32, i32, i32)) -> Option<bool> {
+        let (chunk_pos, chunked_pos) = <(GridChunkPos, ChunkedPos)>::from(GridBlockPos {
+            x: p.0,
+            y: p.1,
+            z: p.2,
+        });
+        // Grid chunks are self-contained: an absent chunk means definitely
+        // air, not "unknown". The grid has no concept of streamed loading.
+        Some(
+            self.chunks
+                .get(&chunk_pos)
+                .map(|e| !e.value().read().get(chunked_pos).is_traversable())
+                .unwrap_or(false),
+        )
+    }
+}
+
+/// Top-level BFS driver. Seeds the BFS from every solid 26-connected neighbour
+/// of the destroyed cell — face, edge, *and* corner — because connectivity in
+/// this game is 26-conn, so any of them could have been the only path between
+/// two pieces. Returns the smaller disconnected component if one fully closes
+/// within budget, `None` otherwise (no split, or unable to verify).
+///
+/// The surface-only BFS only verifies *connectivity*; it never visits cells
+/// surrounded entirely by other solid cells. Once we have a confirmed split
+/// component (its surface), `fill_component` flood-fills inwards to collect
+/// the interior so the entire mass moves together.
+fn run_split_bfs<R: VoxelReader>(
+    reader: &R,
+    destroyed: (i32, i32, i32),
+) -> Option<HashSet<(i32, i32, i32)>> {
+    let starts: Vec<(i32, i32, i32)> = neighbors_26()
+        .map(|(dx, dy, dz)| (destroyed.0 + dx, destroyed.1 + dy, destroyed.2 + dz))
+        .filter(|p| reader.solidity(*p) == Some(true))
+        .collect();
+    if starts.len() < 2 {
+        return None;
+    }
+    let surface = bfs_multi(reader, &starts, SPLIT_BFS_BUDGET)?;
+    fill_component(reader, surface)
+}
+
+/// Flood-fill from the surface set through every 26-connected solid cell
+/// (no surface filter) to capture interior blocks. Returns the union.
+fn fill_component<R: VoxelReader>(
+    reader: &R,
+    surface: HashSet<(i32, i32, i32)>,
+) -> Option<HashSet<(i32, i32, i32)>> {
+    let mut visited = surface;
+    let mut queue: VecDeque<(i32, i32, i32)> = visited.iter().copied().collect();
+    while let Some(p) = queue.pop_front() {
+        for offset in neighbors_26() {
+            let q = (p.0 + offset.0, p.1 + offset.1, p.2 + offset.2);
+            if visited.contains(&q) {
+                continue;
+            }
+            // `?` aborts the whole split if we somehow leak into unloaded
+            // territory (surface should already enclose the mass, so this
+            // is defensive).
+            if !reader.solidity(q)? {
+                continue;
+            }
+            if visited.len() >= FILL_COMPONENT_BUDGET {
+                return None;
+            }
+            visited.insert(q);
+            queue.push_back(q);
+        }
+    }
+    Some(visited)
+}
+
+/// Multi-seed BFS: one frontier per face-neighbour, expanding through 26-
+/// connected solid surface cells. Frontiers union-find together when they
+/// visit a common cell. The first group whose frontiers all empty before
+/// merging into a single universe is returned as the split component.
+///
+/// Surface-only expansion: only solid blocks with at least one 26-air-
+/// neighbour are added to a frontier. Interior cells of a solid mass are
+/// skipped, which keeps the budget useful on dense bodies.
+fn bfs_multi<R: VoxelReader>(
+    reader: &R,
+    starts: &[(i32, i32, i32)],
+    budget: usize,
+) -> Option<HashSet<(i32, i32, i32)>> {
+    let n = starts.len();
+    let mut frontiers: Vec<VecDeque<(i32, i32, i32)>> =
+        starts.iter().map(|p| VecDeque::from([*p])).collect();
+    let mut owner: HashMap<(i32, i32, i32), usize> = HashMap::new();
+    let mut parent: Vec<usize> = (0..n).collect();
+    for (i, p) in starts.iter().enumerate() {
+        owner.insert(*p, i);
+    }
+    let mut total_expanded = n;
+
+    loop {
+        let mut any_active = false;
+        for i in 0..n {
+            let Some(p) = frontiers[i].pop_front() else {
+                continue;
+            };
+            any_active = true;
+            for offset in neighbors_26() {
+                let q = (p.0 + offset.0, p.1 + offset.1, p.2 + offset.2);
+                // Short-circuit on already-visited cells: skip the expensive
+                // `solidity` + `is_surface` reads (each `is_surface` does up
+                // to 26 chunk lookups) and just union the BFSes.
+                if let Some(&prev_i) = owner.get(&q) {
+                    let r1 = uf_find(&mut parent, prev_i);
+                    let r2 = uf_find(&mut parent, i);
+                    if r1 != r2 {
+                        parent[r1] = r2;
+                    }
+                    continue;
+                }
+                // `?` aborts the whole BFS if `q` is in unknown territory
+                // (unloaded chunk) — we can't trust a "bounded" verdict if we
+                // never observed half the boundary.
+                if !reader.solidity(q)? {
+                    continue;
+                }
+                if !is_surface(reader, q)? {
+                    continue;
+                }
+                owner.insert(q, i);
+                frontiers[i].push_back(q);
+                total_expanded += 1;
+                if total_expanded >= budget {
+                    return None;
+                }
+            }
+        }
+
+        // Group frontiers by union-find root and look for any group that's
+        // now fully exhausted while at least one other group is still
+        // distinct. That group is a closed disconnected component.
+        let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
+        for i in 0..n {
+            let r = uf_find(&mut parent, i);
+            groups.entry(r).or_default().push(i);
+        }
+        if groups.len() == 1 {
+            // Every seed has been unioned into the same component, so the
+            // destroyed cell wasn't a bridge — no split is possible regardless
+            // of how much further we'd expand. This is the fast path for
+            // mining a block in the middle of a connected mass.
+            return None;
+        }
+        for (root, members) in &groups {
+            if members.iter().all(|&i| frontiers[i].is_empty()) {
+                let target_root = *root;
+                let component: HashSet<_> = owner
+                    .iter()
+                    .filter(|(_, i)| uf_find(&mut parent, **i) == target_root)
+                    .map(|(p, _)| *p)
+                    .collect();
+                return Some(component);
+            }
+        }
+
+        if !any_active {
+            // All frontiers empty but multiple groups distinct — every group
+            // is a closed component. Pick the smallest as the split target.
+            let mut best: Option<(usize, usize)> = None;
+            for (root, _) in &groups {
+                let target_root = *root;
+                let size = owner
+                    .iter()
+                    .filter(|(_, i)| uf_find(&mut parent, **i) == target_root)
+                    .count();
+                if best.map(|(_, s)| size < s).unwrap_or(true) {
+                    best = Some((target_root, size));
+                }
+            }
+            let (root, _) = best?;
+            let component: HashSet<_> = owner
+                .iter()
+                .filter(|(_, i)| uf_find(&mut parent, **i) == root)
+                .map(|(p, _)| *p)
+                .collect();
+            return Some(component);
+        }
+    }
+}
+
+/// Path-compressing union-find lookup.
+fn uf_find(parent: &mut [usize], i: usize) -> usize {
+    let mut root = i;
+    while parent[root] != root {
+        root = parent[root];
+    }
+    let mut cur = i;
+    while parent[cur] != root {
+        let next = parent[cur];
+        parent[cur] = root;
+        cur = next;
+    }
+    root
+}
+
+/// `Some(true)` if at least one of `p`'s 26 surrounding cells is non-solid.
+/// `None` if any neighbour is in an unloaded (unknown) cell — we can't tell
+/// whether `p` is on the surface or in the interior, so the caller must abort.
+/// Used to restrict BFS expansion to the surface manifold of the source mass.
+fn is_surface<R: VoxelReader>(reader: &R, p: (i32, i32, i32)) -> Option<bool> {
+    for offset in neighbors_26() {
+        if !reader.solidity((p.0 + offset.0, p.1 + offset.1, p.2 + offset.2))? {
+            return Some(true);
+        }
+    }
+    Some(false)
+}
+
+fn neighbors_26() -> impl Iterator<Item = (i32, i32, i32)> {
+    (-1i32..=1).flat_map(|dx| {
+        (-1i32..=1).flat_map(move |dy| {
+            (-1i32..=1).filter_map(move |dz| {
+                if dx == 0 && dy == 0 && dz == 0 {
+                    None
+                } else {
+                    Some((dx, dy, dz))
+                }
+            })
+        })
+    })
+}

--- a/src/agents/movement.rs
+++ b/src/agents/movement.rs
@@ -1,5 +1,5 @@
 use crate::Block;
-use crate::world::{BlockPos, Realm, VoxelWorld};
+use crate::world::{BlockPos, GridBlockPos, Realm, VoxelGrid, VoxelWorld};
 use avian3d::prelude::{Friction, LinearVelocity, LockedAxes, ShapeHits};
 use bevy::{
     prelude::*,
@@ -91,13 +91,15 @@ fn update_grounded_and_material(
 }
 
 /// Locks all axes when any of three axis-line probes is inside a non-traversable
-/// voxel. Three probes (top, mid, bottom) are sufficient because their 0.80m
-/// spacing is less than block height, so any block intersecting the body's
-/// vertical span contains at least one. Tests the central axis rather than the
-/// AABB so the rounded sides of the capsule don't false-trigger freeze when they
-/// brush a corner block the capsule isn't actually touching.
+/// voxel — either in the static world or in any movable `VoxelGrid`. Three
+/// probes (top, mid, bottom) are sufficient because their 0.80m spacing is
+/// less than block height, so any block intersecting the body's vertical span
+/// contains at least one. Tests the central axis rather than the AABB so the
+/// rounded sides of the capsule don't false-trigger freeze when they brush a
+/// corner block the capsule isn't actually touching.
 fn freeze_when_voxel_intersected(
     blocks: Res<VoxelWorld>,
+    grids: Query<(&GlobalTransform, &VoxelGrid)>,
     mut query: Query<(
         &Transform,
         &Realm,
@@ -115,14 +117,27 @@ fn freeze_when_voxel_intersected(
             c - Vec3::Y * inset_h,
         ];
         let intersecting = probes.iter().any(|p| {
-            !blocks
-                .get_block(BlockPos {
-                    x: p.x.floor() as i32,
-                    y: p.y.floor() as i32,
-                    z: p.z.floor() as i32,
-                    realm: *realm,
-                })
-                .is_traversable()
+            let world_block = blocks.get_block(BlockPos {
+                x: p.x.floor() as i32,
+                y: p.y.floor() as i32,
+                z: p.z.floor() as i32,
+                realm: *realm,
+            });
+            if !world_block.is_traversable() {
+                return true;
+            }
+            for (xform, grid) in grids.iter() {
+                let local = xform.affine().inverse().transform_point3(*p);
+                let pos = GridBlockPos {
+                    x: local.x.floor() as i32,
+                    y: local.y.floor() as i32,
+                    z: local.z.floor() as i32,
+                };
+                if !grid.get_block(pos).is_traversable() {
+                    return true;
+                }
+            }
+            false
         });
         if intersecting {
             *locked = LockedAxes::ALL_LOCKED;

--- a/src/agents/movement.rs
+++ b/src/agents/movement.rs
@@ -1,22 +1,27 @@
 use crate::Block;
 use crate::world::{BlockPos, Realm, VoxelWorld};
+use avian3d::prelude::{Friction, LinearVelocity, LockedAxes, ShapeHits};
 use bevy::{
     prelude::*,
     time::{Time, Timer},
 };
-use itertools::{Itertools, iproduct};
+
 const FREE_FLY_Y_SPEED: f32 = 100.;
 const ACC_MULT: f32 = 150.;
+// Pulls voxel-intersection probes inward so resting contact (Avian sinks the
+// collider into the floor by ~0.005-0.02 blocks) doesn't false-trigger freeze.
+const VOXEL_INTERSECT_INSET: f32 = 0.05;
 
 pub struct MovementPlugin;
 
 impl Plugin for MovementPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreUpdate, update_stepped_block)
+        app.add_systems(PreUpdate, update_grounded_and_material)
+            .add_systems(PreUpdate, freeze_when_voxel_intersected)
             .add_systems(Update, process_jumps)
             .add_systems(Update, process_freefly)
             .add_systems(Update, apply_acc_free_fly)
-            .add_systems(Update, (apply_acc, apply_gravity, apply_velocity).chain());
+            .add_systems(Update, apply_acc);
     }
 }
 
@@ -42,246 +47,142 @@ pub struct Jumping {
 #[derive(Component)]
 pub struct Crouching(pub bool);
 
+/// Half-extents of the entity's body, in body-local coordinates. Only `y` is
+/// read (sets the vertical span of `freeze_when_voxel_intersected`'s probes).
 #[derive(Component)]
-pub struct AABB(pub Vec3);
+pub struct BodyExtents(pub Vec3);
 
-// both describe the speed and the direction the entity wants to go towards
+#[derive(Component)]
+pub struct Grounded(pub bool);
+
 #[derive(Component)]
 pub struct Heading(pub Vec3);
 
-// the actual speed vector of the entity, most of the time it is similar to Heading but not always!
-#[derive(Component)]
-pub struct Velocity(pub Vec3);
-
-// the gravity that the entity will be subject to
-#[derive(Component)]
-pub struct Gravity(pub f32);
-
-fn extent(v: f32, size: f32) -> Vec<i32> {
-    if size > 0. {
-        ((v.floor() as i32)..=((size + v).floor() as i32)).collect_vec()
-    } else {
-        (((size + v).floor() as i32)..=(v.floor() as i32))
-            .rev()
-            .collect_vec()
+fn update_grounded_and_material(
+    blocks: Res<VoxelWorld>,
+    mut query: Query<(
+        &Realm,
+        &ShapeHits,
+        &mut Grounded,
+        &mut SteppingOn,
+        &mut Friction,
+    )>,
+) {
+    for (realm, hits, mut grounded, mut stepping_on, mut friction) in query.iter_mut() {
+        if let Some(hit) = hits.iter().next() {
+            grounded.0 = true;
+            // Sample just below the hit surface so we identify the block under
+            // the contact, not the air immediately above it.
+            let p = hit.point1 - Vec3::Y * 0.05;
+            stepping_on.0 = blocks.get_block(BlockPos {
+                x: p.x.floor() as i32,
+                y: p.y.floor() as i32,
+                z: p.z.floor() as i32,
+                realm: *realm,
+            });
+        } else {
+            grounded.0 = false;
+            stepping_on.0 = Block::Air;
+        }
+        let f = stepping_on.0.friction();
+        friction.dynamic_coefficient = f;
+        friction.static_coefficient = f;
     }
 }
 
-fn blocks_perp_y(pos: Vec3, realm: Realm, aabb: &AABB) -> impl Iterator<Item = BlockPos> {
-    iproduct!(extent(pos.x, aabb.0.x), extent(pos.z, aabb.0.z)).map(move |(x, z)| BlockPos {
-        x,
-        y: pos.y.floor() as i32,
-        z,
-        realm: realm,
-    })
-}
-
-fn blocks_perp_z(pos: Vec3, realm: Realm, aabb: &AABB) -> impl Iterator<Item = BlockPos> {
-    iproduct!(extent(pos.x, aabb.0.x), extent(pos.y, aabb.0.y)).map(move |(x, y)| BlockPos {
-        x,
-        y,
-        z: pos.z.floor() as i32,
-        realm: realm,
-    })
-}
-
-fn blocks_perp_x(pos: Vec3, realm: Realm, aabb: &AABB) -> impl Iterator<Item = BlockPos> {
-    iproduct!(extent(pos.y, aabb.0.y), extent(pos.z, aabb.0.z)).map(move |(y, z)| BlockPos {
-        x: pos.x.floor() as i32,
-        y,
-        z,
-        realm: realm,
-    })
-}
-
-fn update_stepped_block(
+/// Locks all axes when any of three axis-line probes is inside a non-traversable
+/// voxel. Three probes (top, mid, bottom) are sufficient because their 0.80m
+/// spacing is less than block height, so any block intersecting the body's
+/// vertical span contains at least one. Tests the central axis rather than the
+/// AABB so the rounded sides of the capsule don't false-trigger freeze when they
+/// brush a corner block the capsule isn't actually touching.
+fn freeze_when_voxel_intersected(
     blocks: Res<VoxelWorld>,
-    mut query: Query<(&Transform, &Realm, &AABB, &mut SteppingOn)>,
+    mut query: Query<(
+        &Transform,
+        &Realm,
+        &BodyExtents,
+        &mut LockedAxes,
+        &mut LinearVelocity,
+    )>,
 ) {
-    for (transform, realm, aabb, mut stepping_on) in query.iter_mut() {
-        let below = transform.translation + Vec3::new(0., -0.01, 0.);
-        let mut closest_block = Block::Air;
-        let mut min_dist = f32::INFINITY;
-        for block_pos in blocks_perp_y(below, *realm, aabb) {
-            let block = blocks.get_block(block_pos);
-            if block.is_traversable() {
-                continue;
-            }
-            let dist = (below.x - block_pos.x as f32).abs() - (below.y - block_pos.y as f32).abs();
-            if dist < min_dist {
-                min_dist = dist;
-                closest_block = block;
-            }
+    for (transform, realm, extents, mut locked, mut velocity) in query.iter_mut() {
+        let c = transform.translation;
+        let inset_h = extents.0.y - VOXEL_INTERSECT_INSET;
+        let probes = [
+            c + Vec3::Y * inset_h,
+            c,
+            c - Vec3::Y * inset_h,
+        ];
+        let intersecting = probes.iter().any(|p| {
+            !blocks
+                .get_block(BlockPos {
+                    x: p.x.floor() as i32,
+                    y: p.y.floor() as i32,
+                    z: p.z.floor() as i32,
+                    realm: *realm,
+                })
+                .is_traversable()
+        });
+        if intersecting {
+            *locked = LockedAxes::ALL_LOCKED;
+            velocity.0 = Vec3::ZERO;
+        } else {
+            *locked = LockedAxes::ROTATION_LOCKED;
         }
-        stepping_on.0 = closest_block;
     }
 }
 
 fn process_jumps(
     time: Res<Time>,
-    mut query: Query<(&mut Jumping, &mut Velocity, &SteppingOn), With<Walking>>,
+    mut query: Query<(&mut Jumping, &mut LinearVelocity, &Grounded), With<Walking>>,
 ) {
-    for (mut jumping, mut velocity, stepping_on) in query.iter_mut() {
+    for (mut jumping, mut velocity, grounded) in query.iter_mut() {
         jumping.cd.tick(time.delta());
-        if jumping.intent && jumping.cd.is_finished() && !stepping_on.0.is_traversable() {
-            velocity.0.y += jumping.force;
+        if jumping.intent && jumping.cd.is_finished() && grounded.0 {
+            velocity.0.y = jumping.force;
             jumping.cd.reset();
         }
     }
 }
 
-fn process_freefly(mut query: Query<(&mut Velocity, &Jumping, &Crouching), With<FreeFly>>) {
+fn process_freefly(
+    mut query: Query<(&mut LinearVelocity, &Jumping, &Crouching), With<FreeFly>>,
+) {
     for (mut velocity, jumping, crouching) in query.iter_mut() {
         velocity.0.y = (jumping.intent as i32 - crouching.0 as i32) as f32 * FREE_FLY_Y_SPEED;
-    }
-}
-
-fn apply_gravity(
-    blocks: Res<VoxelWorld>,
-    time: Res<Time>,
-    mut query: Query<(&Transform, &Realm, &mut Velocity, &Gravity), With<Walking>>,
-) {
-    for (transform, realm, mut velocity, gravity) in query.iter_mut() {
-        if !blocks.is_col_loaded(transform.translation, *realm) {
-            continue;
-        }
-        velocity.0 += Vec3::new(0., -gravity.0 * time.delta_secs(), 0.);
     }
 }
 
 fn apply_acc(
     blocks: Res<VoxelWorld>,
     time: Res<Time>,
-    mut query: Query<(&Heading, &mut Velocity, &Transform, &Realm, &SteppingOn), With<Walking>>,
+    mut query: Query<
+        (&Heading, &mut LinearVelocity, &Transform, &Realm, &SteppingOn),
+        With<Walking>,
+    >,
 ) {
     for (heading, mut velocity, transform, realm, stepping_on) in query.iter_mut() {
         if !blocks.is_col_loaded(transform.translation, *realm) {
             continue;
         }
-        // get the block the entity is standing on if the entity has an AABB
-        let friction: f32 = stepping_on.0.friction();
-        let slowing: f32 = stepping_on.0.slowing();
-        // applying slowing
-        let heading = heading.0 * slowing;
-        // make velocity inch towards heading
-        let mut diff = heading - velocity.0;
-        if diff.y.is_nan() {
-            diff.y = 0.;
-        }
+        let target = Vec2::new(heading.0.x, heading.0.z) * stepping_on.0.slowing();
+        let current = Vec2::new(velocity.0.x, velocity.0.z);
+        let diff = target - current;
         let diff_len = diff.length();
         if diff_len == 0. {
             continue;
         }
-        let c = (time.delta_secs() * friction * ACC_MULT / diff_len.max(1.)).min(1.);
-        let acc: Vec3 = c * diff;
-        velocity.0 += acc;
+        let c = (time.delta_secs() * ACC_MULT / diff_len.max(1.)).min(1.);
+        let acc = c * diff;
+        velocity.0.x += acc.x;
+        velocity.0.z += acc.y;
     }
 }
 
-fn apply_acc_free_fly(mut query: Query<(&Heading, &mut Velocity), With<FreeFly>>) {
+fn apply_acc_free_fly(mut query: Query<(&Heading, &mut LinearVelocity), With<FreeFly>>) {
     for (heading, mut velocity) in query.iter_mut() {
         velocity.0.x = heading.0.x;
         velocity.0.z = heading.0.z;
-    }
-}
-
-fn apply_velocity(
-    blocks: Res<VoxelWorld>,
-    time: Res<Time>,
-    mut query: Query<(&mut Velocity, &mut Transform, &Realm, &AABB)>,
-) {
-    for (mut velocity, mut transform, realm, aabb) in query.iter_mut() {
-        if !blocks.is_col_loaded(transform.translation, *realm) {
-            continue;
-        }
-        let applied_velocity = velocity.0 * time.delta_secs();
-        // split the motion on all 3 axis, check for collisions, adjust the final speed vector if there's any
-        // x
-        let xpos = if applied_velocity.x > 0. {
-            aabb.0.x + transform.translation.x
-        } else {
-            transform.translation.x
-        };
-        let mut stopped = false;
-        for x in extent(xpos, applied_velocity.x).into_iter().skip(1) {
-            let pos_x = Vec3 {
-                x: x as f32,
-                y: transform.translation.y,
-                z: transform.translation.z,
-            };
-            if blocks_perp_x(pos_x, *realm, aabb).any(|pos| !blocks.get_block(pos).is_traversable())
-            {
-                // there's a collision in this direction, stop at the block limit
-                if applied_velocity.x > 0. {
-                    transform.translation.x = pos_x.x - aabb.0.x - 0.001;
-                } else {
-                    transform.translation.x = pos_x.x + 1.001;
-                }
-                velocity.0.x = 0.;
-                stopped = true;
-                break;
-            }
-        }
-        if !stopped {
-            transform.translation.x += applied_velocity.x;
-        }
-        // y
-        let ypos: f32 = if applied_velocity.y > 0. {
-            aabb.0.y + transform.translation.y
-        } else {
-            transform.translation.y
-        };
-        let mut stopped = false;
-        for y in extent(ypos, applied_velocity.y).into_iter().skip(1) {
-            let pos_y = Vec3 {
-                x: transform.translation.x,
-                y: y as f32,
-                z: transform.translation.z,
-            };
-            if blocks_perp_y(pos_y, *realm, aabb).any(|pos| !blocks.get_block(pos).is_traversable())
-            {
-                // there's a collision in this direction, stop at the block limit
-                if applied_velocity.y > 0. {
-                    transform.translation.y = pos_y.y - aabb.0.y - 0.001;
-                } else {
-                    transform.translation.y = pos_y.y + 1.001;
-                }
-                velocity.0.y = 0.;
-                stopped = true;
-                break;
-            }
-        }
-        if !stopped {
-            transform.translation.y += applied_velocity.y;
-        }
-        // z
-        let zpos: f32 = if applied_velocity.z > 0. {
-            aabb.0.z + transform.translation.z
-        } else {
-            transform.translation.z
-        };
-        let mut stopped = false;
-        for z in extent(zpos, applied_velocity.z).into_iter().skip(1) {
-            let pos_z = Vec3 {
-                x: transform.translation.x,
-                y: transform.translation.y,
-                z: z as f32,
-            };
-            if blocks_perp_z(pos_z, *realm, aabb).any(|pos| !blocks.get_block(pos).is_traversable())
-            {
-                // there's a collision in this direction, stop at the block limit
-                if applied_velocity.z > 0. {
-                    transform.translation.z = pos_z.z - aabb.0.z - 0.001;
-                } else {
-                    transform.translation.z = pos_z.z + 1.001;
-                }
-                velocity.0.z = 0.;
-                stopped = true;
-                break;
-            }
-        }
-        if !stopped {
-            transform.translation.z += applied_velocity.z;
-        }
     }
 }

--- a/src/agents/player.rs
+++ b/src/agents/player.rs
@@ -5,14 +5,24 @@ use super::{
 use crate::world::{BlockRayCastHit, Realm};
 use crate::{
     Block,
-    agents::{AABB, Gravity, Heading, Jumping, Velocity},
+    agents::{BodyExtents, Grounded, Heading, Jumping},
     items::{InventoryTrait, Item, Stack, new_inventory},
     sounds::{BlockSoundCD, FootstepCD, on_item_get},
     ui::{CursorGrabbed, ItemHolder},
 };
+use avian3d::prelude::{
+    CoefficientCombine, Collider, Friction, LinearVelocity, LockedAxes, RigidBody, ShapeCaster,
+};
 use bevy::{math::Vec3, prelude::*};
 use leafwing_input_manager::prelude::*;
 use std::time::Duration;
+
+/// Half-extents of the player's bounding box. Width/depth equal the capsule
+/// radius; height equals half the total capsule height (cylinder + caps).
+pub const PLAYER_HALF_EXTENTS: Vec3 = Vec3::new(0.25, 0.85, 0.25);
+// Avian's `Collider::capsule(radius, length)` puts hemispheres on top of
+// `length`, so cylinder length is total height minus two radii.
+const PLAYER_CAPSULE_LENGTH: f32 = PLAYER_HALF_EXTENTS.y * 2. - PLAYER_HALF_EXTENTS.x * 2.;
 
 const WALK_SPEED: f32 = 7.;
 const FREE_FLY_X_SPEED: f32 = 500.;
@@ -104,7 +114,31 @@ pub fn spawn_player(mut commands: Commands, key_binds: Res<KeyBinds>) {
             },
             Visibility::default(),
             realm,
-            Gravity(50.),
+            RigidBody::Dynamic,
+            // Capsule's rounded base slides cleanly across coplanar triangle
+            // edges in the chunk trimesh; a flat-bottom cuboid catches on them.
+            Collider::capsule(PLAYER_HALF_EXTENTS.x, PLAYER_CAPSULE_LENGTH),
+            // Material friction lives on the player and is rewritten each frame
+            // from `SteppingOn`. `Min` combine ensures whichever of (player,
+            // terrain) is slipperier wins, so ice etc. dominate.
+            Friction::new(1.0).with_combine_rule(CoefficientCombine::Min),
+            LockedAxes::ROTATION_LOCKED,
+            LinearVelocity::default(),
+            ShapeCaster::new(
+                Collider::cuboid(
+                    PLAYER_HALF_EXTENTS.x * 1.9,
+                    0.05,
+                    PLAYER_HALF_EXTENTS.z * 1.9,
+                ),
+                Vec3::new(0., -PLAYER_HALF_EXTENTS.y + 0.05, 0.),
+                Quat::IDENTITY,
+                Dir3::NEG_Y,
+            )
+            .with_max_distance(0.15),
+            Grounded(false),
+            BodyExtents(PLAYER_HALF_EXTENTS),
+        ))
+        .insert((
             Heading(Vec3::default()),
             Speed(WALK_SPEED),
             Jumping {
@@ -112,8 +146,6 @@ pub fn spawn_player(mut commands: Commands, key_binds: Res<KeyBinds>) {
                 cd: Timer::new(Duration::from_millis(500), TimerMode::Once),
                 intent: false,
             },
-            AABB(Vec3::new(0.5, 1.7, 0.5)),
-            Velocity(Vec3::default()),
             TargetBlock(None),
             ItemHolder::Inventory(inventory),
             PlayerControlled,

--- a/src/agents/player.rs
+++ b/src/agents/player.rs
@@ -2,7 +2,7 @@ use super::{
     Crouching, FreeFly, Speed, SteppingOn, Walking, block_action::BlockActionPlugin,
     key_binds::KeyBinds,
 };
-use crate::world::{BlockRayCastHit, Realm};
+use crate::world::{BlockRayCastHit, GridBlockPos, Realm};
 use crate::{
     Block,
     agents::{BodyExtents, Grounded, Heading, Jumping},
@@ -63,8 +63,41 @@ impl Plugin for PlayerPlugin {
 #[derive(Component)]
 pub struct PlayerControlled;
 
+/// What the player's camera ray is currently aimed at. Either a block in the
+/// static `VoxelWorld` (per-realm, axis-aligned) or a block on a movable
+/// `VoxelGrid` (entity-anchored). Grid hits carry a grid-local face normal
+/// so consumers can work in the grid's local frame (parented effects,
+/// placement offsets) without re-transforming through `GlobalTransform`.
+#[derive(Debug, Clone)]
+pub enum TargetKind {
+    World(BlockRayCastHit),
+    Grid {
+        grid: Entity,
+        pos: GridBlockPos,
+        /// Face normal in grid-local space (axis-aligned, ±X/Y/Z).
+        normal_local: Vec3,
+    },
+}
+
+impl PartialEq for TargetKind {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (TargetKind::World(a), TargetKind::World(b)) => a.pos == b.pos,
+            (
+                TargetKind::Grid {
+                    grid: g1, pos: p1, ..
+                },
+                TargetKind::Grid {
+                    grid: g2, pos: p2, ..
+                },
+            ) => g1 == g2 && p1 == p2,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Component)]
-pub struct TargetBlock(pub Option<BlockRayCastHit>);
+pub struct TargetBlock(pub Option<TargetKind>);
 
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 pub enum Dir {

--- a/src/block/block.rs
+++ b/src/block/block.rs
@@ -51,4 +51,39 @@ impl Block {
             _ => false
         }
     }
+
+    /// Mass per 1m³ block. Used by `spawn_voxel_grid` to set the rigid body's
+    /// total mass and centre of mass. `0` for traversable blocks (they don't
+    /// contribute to a grid). Values are tuned for game feel — relative
+    /// ratios approximate real materials (wood < soil < stone < ore) but
+    /// magnitudes are kept modest so Avian's solver stays stable.
+    pub fn density(&self) -> f32 {
+        if matches!(self, Block::Air | Block::SeaBlock) {
+            return 0.0;
+        }
+        if self.is_foliage() {
+            return 0.1;
+        }
+        let families = self.families();
+        if families.contains(&BlockFamily::Ore) {
+            return 3.0;
+        }
+        if families.contains(&BlockFamily::Stone) {
+            return 2.0;
+        }
+        if families.contains(&BlockFamily::Crystal) {
+            return 0.8;
+        }
+        if families.contains(&BlockFamily::Wood)
+            || families.contains(&BlockFamily::Log)
+            || families.contains(&BlockFamily::Planks)
+        {
+            return 0.6;
+        }
+        if families.contains(&BlockFamily::Soil) {
+            return 1.0;
+        }
+        // Fall-through for one-off blocks (Campfire, Smelter, Kiln, …).
+        1.0
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,11 @@ include!(concat!(env!("OUT_DIR"), "/blocks.rs"));
 use avian3d::prelude::*;
 use bevy::{image::{ImageAddressMode, ImageFilterMode, ImageSamplerDescriptor}, log::LogPlugin, prelude::*, window::PresentMode};
 use crossbeam::channel::unbounded;
-use world::VoxelWorld;
+use world::{GridBlockPos, VoxelWorld};
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
 use sounds::SoundPlugin;
 use ui::UIPlugin;
-use render::{Render, TextureLoadPlugin};
+use render::{BlockTexState, Render, TextureLoadPlugin, TextureMap, spawn_voxel_grid};
 use agents::{MovementPlugin, PlayerPlugin};
 use world::TerrainLoadPlugin;
 #[cfg(feature = "log_inspector")]
@@ -92,9 +92,32 @@ fn client() {
         .add_plugins(TerrainLoadPlugin)
         .add_plugins(Render)
         .add_plugins(SoundPlugin)
+        .add_systems(OnEnter(BlockTexState::Mapped), spawn_demo_grid)
         ;
 
     app.run();
+}
+
+/// Drops a small cobblestone cube just in front of the player spawn so the
+/// voxel-rigidbody pipeline (render, gravity, collisions, break/place) is
+/// exercised end-to-end on startup. Strip when no longer needed.
+fn spawn_demo_grid(mut commands: Commands, texture_map: Res<TextureMap>) {
+    // Player SPAWN is (280, 500, -150) facing +Z. The cube spawns 4m forward
+    // and 5m up; 3m³ keeps it visibly comparable to the 1.7m player capsule.
+    spawn_voxel_grid(
+        &mut commands,
+        &texture_map,
+        Transform::from_xyz(280., 505., -146.),
+        |grid| {
+            for x in 0..3 {
+                for y in 0..3 {
+                    for z in 0..3 {
+                        grid.set_block(GridBlockPos { x, y, z }, Block::Cobblestone);
+                    }
+                }
+            }
+        },
+    );
 }
 
 #[cfg(feature = "log_inspector")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod sounds;
 mod generation;
 mod logging;
 include!(concat!(env!("OUT_DIR"), "/blocks.rs"));
+use avian3d::prelude::*;
 use bevy::{image::{ImageAddressMode, ImageFilterMode, ImageSamplerDescriptor}, log::LogPlugin, prelude::*, window::PresentMode};
 use crossbeam::channel::unbounded;
 use world::VoxelWorld;
@@ -78,6 +79,12 @@ fn client() {
             seed: SEED,
             rng: ChaCha8Rng::seed_from_u64(SEED)
         })
+        .add_plugins(PhysicsPlugins::default())
+        .insert_resource(Gravity(Vec3::new(0., -50., 0.)));
+    if std::env::args().any(|a| a == "--debug-physics") {
+        app.add_plugins(PhysicsDebugPlugin::default());
+    }
+    app
         .add_plugins(PlayerPlugin)
         .add_plugins(TextureLoadPlugin)
         .add_plugins(UIPlugin)

--- a/src/render/camera.rs
+++ b/src/render/camera.rs
@@ -1,10 +1,11 @@
 use crate::Block;
-use crate::agents::Velocity;
+use crate::agents::PLAYER_HALF_EXTENTS;
 use crate::world::{Realm, VoxelWorld};
 use crate::{
-    agents::{AABB, PlayerControlled, PlayerSpawn},
+    agents::{PlayerControlled, PlayerSpawn},
     ui::CursorGrabbed,
 };
+use avian3d::prelude::LinearVelocity;
 use bevy::prelude::*;
 use bevy::window::{CursorGrabMode, CursorOptions};
 use leafwing_input_manager::prelude::*;
@@ -64,14 +65,15 @@ pub struct CameraSpawn;
 fn cam_setup(
     mut commands: Commands,
     mut cursor_options: Query<&mut CursorOptions>,
-    player_query: Query<(Entity, &AABB), With<PlayerControlled>>,
+    player_query: Query<Entity, With<PlayerControlled>>,
 ) {
     let input_map = InputMap::default().with_dual_axis(CameraMovement::Pan, MouseMove::default());
-    let (player, aabb) = player_query.single().unwrap();
+    let player = player_query.single().unwrap();
+    // Eye sits 0.05 below the top of the body (transform-centered collider).
     let cam = commands
         .spawn((
             Camera3d::default(),
-            Transform::from_xyz(aabb.0.x / 2., aabb.0.y - 0.05, aabb.0.z / 2.).looking_at(
+            Transform::from_xyz(0., PLAYER_HALF_EXTENTS.y - 0.05, 0.).looking_at(
                 Vec3 {
                     x: 0.,
                     y: 0.,
@@ -102,7 +104,7 @@ fn cam_setup(
 
 fn adaptative_fov(
     cam_query: Single<(&Transform, &mut Projection)>,
-    player_query: Single<&Velocity, With<PlayerControlled>>,
+    player_query: Single<&LinearVelocity, With<PlayerControlled>>,
     time: Res<Time>,
 ) {
     let velocity = player_query.into_inner();

--- a/src/render/effects/block_breaking.rs
+++ b/src/render/effects/block_breaking.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 use bevy::{asset::LoadedFolder, image::TRANSPARENT_IMAGE_HANDLE, prelude::*};
 use itertools::Itertools;
-use crate::{agents::{BlockActionType, BlockLootAction, TargetBlock}, render::{BlockTexState, BlockTextureFolder}};
+use crate::{agents::{BlockActionType, BlockLootAction, TargetBlock, TargetKind}, render::{BlockTexState, BlockTextureFolder}};
 
 pub struct BlockBreakingEffectPlugin;
 
@@ -61,9 +61,19 @@ fn add_break_animation(
     for (player, target_opt, breaking) in block_action_query.iter() {
         if !matches!(breaking.action_type, BlockActionType::Breaking) {
             continue;
-        } 
-        let Some(target) = &target_opt.0 else {
-            continue;
+        }
+        // Compute the overlay quad in the targeted block's *local* frame
+        // (block-corner origin, axis-aligned face normal). For world targets
+        // the local frame is the world frame; for grid targets the overlay
+        // is parented to the grid root so it inherits rotation/motion.
+        let (origin_local, normal_local, parent) = match &target_opt.0 {
+            Some(TargetKind::World(hit)) => (Vec3::from(hit.pos), hit.normal, None),
+            Some(TargetKind::Grid { grid, pos, normal_local, .. }) => (
+                Vec3::new(pos.x as f32, pos.y as f32, pos.z as f32),
+                *normal_local,
+                Some(*grid),
+            ),
+            None => continue,
         };
         let quad_handle = meshes.add(Rectangle::new(1., 1.));
         let material_handle = materials.add(StandardMaterial {
@@ -72,15 +82,24 @@ fn add_break_animation(
             unlit: true,
             ..default()
         });
-        let translation = <_ as Into<Vec3>>::into(target.pos) 
-            + target.normal.max(Vec3::ZERO) 
-            + target.normal*0.001 
-            + (Vec3::ONE-target.normal.abs())*0.5;
-        let effect = commands.spawn((
+        // Place the quad just outside the targeted face, centred on the face.
+        let translation = origin_local
+            + normal_local.max(Vec3::ZERO)
+            + normal_local * 0.001
+            + (Vec3::ONE - normal_local.abs()) * 0.5;
+        // `looking_at` uses local axes when the entity is parented, which is
+        // exactly what we want — the quad stays oriented to the face even as
+        // the grid rotates.
+        let mut effect_cmds = commands.spawn((
             Mesh3d(quad_handle.clone()),
             MeshMaterial3d(material_handle.clone()),
-            Transform::from_translation(translation).looking_at(translation-target.normal, Vec3::Y)
-        )).id();
+            Transform::from_translation(translation)
+                .looking_at(translation - normal_local, Vec3::Y),
+        ));
+        if let Some(grid_entity) = parent {
+            effect_cmds.insert(ChildOf(grid_entity));
+        }
+        let effect = effect_cmds.id();
         commands.entity(player).insert(BreakingEffect(effect));
     }
 }

--- a/src/render/mesh_draw.rs
+++ b/src/render/mesh_draw.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use avian3d::prelude::{Collider, Friction, RigidBody};
 use bevy::camera::primitives::Aabb;
 use bevy::camera::visibility::NoFrustumCulling;
 use bevy::prelude::*;
@@ -6,7 +7,7 @@ use itertools::Itertools;
 use strum::IntoEnumIterator;
 use crate::agents::PlayerControlled;
 use crate::block::Face;
-use crate::render::mesh_thread::{setup_mesh_thread, update_shared_load_area, MeshReciever, SharedPlayerCol};
+use crate::render::mesh_thread::{setup_mesh_thread, update_shared_load_area, ColliderReciever, MeshReciever, SharedPlayerCol};
 use crate::render::MeshOrderSender;
 use crate::world::pos2d::chunks_in_col;
 use crate::world::{ChunkPos, ColUnloadEvent, PlayerCol, VoxelWorld, CHUNK_S1};
@@ -22,11 +23,13 @@ impl Plugin for Draw3d {
         app
             .add_plugins(TextureArrayPlugin)
             .insert_resource(ChunkEntities::new())
+            .insert_resource(ChunkColliderEntities::new())
             .insert_resource(SharedPlayerCol::default())
             .add_systems(OnEnter(BlockTexState::Mapped),  setup_mesh_thread)
             .add_systems(Update, update_shared_load_area)
             .add_systems(Update, mark_lod_remesh)
             .add_systems(Update, pull_meshes.run_if(in_state(BlockTexState::Mapped)))
+            .add_systems(Update, pull_colliders.run_if(in_state(BlockTexState::Mapped)))
             .add_systems(Update, on_col_unload)
             .add_systems(PostUpdate, chunk_culling)
             ;
@@ -111,10 +114,55 @@ pub fn pull_meshes(
     }
 }
 
+pub fn pull_colliders(
+    mut commands: Commands,
+    collider_reciever: Res<ColliderReciever>,
+    mut chunk_collider_ents: ResMut<ChunkColliderEntities>,
+    mut collider_query: Query<&mut Collider>,
+    blocks: Res<VoxelWorld>,
+) {
+    let received: Vec<_> = collider_reciever.0.try_iter().collect();
+    // Coalesce per chunk_pos so stale geometry is discarded.
+    for (collider_opt, chunk_pos, _lod) in
+        received.into_iter().rev().unique_by(|(_, pos, _)| *pos)
+    {
+        let Some(collider) = collider_opt else {
+            if let Some(ent) = chunk_collider_ents.0.remove(&chunk_pos) {
+                commands.entity(ent).despawn();
+            }
+            continue;
+        };
+        if let Some(&ent) = chunk_collider_ents.0.get(&chunk_pos) {
+            if let Ok(mut handle) = collider_query.get_mut(ent) {
+                *handle = collider;
+            }
+        } else if blocks.chunks.contains_key(&chunk_pos) {
+            let ent = commands
+                .spawn((
+                    RigidBody::Static,
+                    collider,
+                    // Block-side friction is uniform; per-block material
+                    // friction is carried on the player and combines via Min.
+                    Friction::new(1.0),
+                    Transform::from_translation(
+                        Vec3::new(
+                            chunk_pos.x as f32,
+                            chunk_pos.y as f32,
+                            chunk_pos.z as f32,
+                        ) * CHUNK_S1 as f32,
+                    ),
+                ))
+                .id();
+            chunk_collider_ents.0.insert(chunk_pos, ent);
+        }
+    }
+}
+
 pub fn on_col_unload(
     mut commands: Commands,
     mut ev_unload: MessageReader<ColUnloadEvent>,
     mut chunk_ents: ResMut<ChunkEntities>,
+    mut chunk_collider_ents: ResMut<ChunkColliderEntities>,
     mesh_query: Query<&Mesh3d>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
@@ -128,6 +176,9 @@ pub fn on_col_unload(
                     commands.entity(ent).despawn();
                 }
             }
+            if let Some(ent) = chunk_collider_ents.0.remove(&chunk_pos) {
+                commands.entity(ent).despawn();
+            }
         }
     }
 }
@@ -138,5 +189,14 @@ pub struct ChunkEntities(pub HashMap::<(ChunkPos, Face), Entity>);
 impl ChunkEntities {
     pub fn new() -> Self {
         ChunkEntities(HashMap::new())
+    }
+}
+
+#[derive(Resource)]
+pub struct ChunkColliderEntities(pub HashMap<ChunkPos, Entity>);
+
+impl ChunkColliderEntities {
+    pub fn new() -> Self {
+        ChunkColliderEntities(HashMap::new())
     }
 }

--- a/src/render/mesh_draw.rs
+++ b/src/render/mesh_draw.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use avian3d::debug_render::DebugRender;
 use avian3d::prelude::{Collider, Friction, RigidBody};
 use bevy::camera::primitives::Aabb;
 use bevy::camera::visibility::NoFrustumCulling;
@@ -144,6 +145,10 @@ pub fn pull_colliders(
                     // Block-side friction is uniform; per-block material
                     // friction is carried on the player and combines via Min.
                     Friction::new(1.0),
+                    // World chunks are too large to render usefully in the
+                    // physics debug overlay; suppress them so the player and
+                    // voxel grids remain visible.
+                    DebugRender::none(),
                     Transform::from_translation(
                         Vec3::new(
                             chunk_pos.x as f32,

--- a/src/render/mesh_logic.rs
+++ b/src/render/mesh_logic.rs
@@ -15,7 +15,7 @@ use crate::world::CHUNK_S1;
 use crate::{
     Block,
     block::Face,
-    world::{CHUNKP_S3, Chunk, ChunkPos, WATER_H, linearize, pad_linearize},
+    world::{CHUNKP_S3, Chunk, WATER_H, linearize, pad_linearize},
 };
 
 const MASK_XYZ: u64 = 0b111111_111111_111111;
@@ -72,13 +72,17 @@ impl Chunk {
 
     /// Doesn't work with lod > 2, because chunks are of size 62 (to get to 64 with padding) and 62 = 2*31
     /// TODO: make it work with lod > 2 if necessary (by truncating quads)
+    ///
+    /// `water_chunk_y` is the chunk's world y-coordinate used only to attenuate
+    /// underwater lighting. Pass `None` to skip water tinting (e.g. for movable
+    /// voxel grids whose world-y changes with `Transform`).
     pub fn create_face_meshes(
         &self,
         texture_map: impl TextureMapTrait,
         lod: usize,
-        chunk_pos: ChunkPos,
+        water_chunk_y: Option<i32>,
     ) -> [Option<Mesh>; 6] {
-        let cy = chunk_pos.y as usize * CHUNK_S1 as usize;
+        let water_cy = water_chunk_y.map(|y| y as usize * CHUNK_S1 as usize);
         // Gathering binary greedy meshing input data
         let mesh_data_span = info_span!("mesh voxel data", name = "mesh voxel data").entered();
         let voxels = self.voxel_data_lod(lod);
@@ -121,10 +125,12 @@ impl Chunk {
                     _ => (1., 1., 1.),
                 };
                 if neighbor_block == Block::SeaBlock {
-                    let dist_to_surface = (WATER_H as usize - cy - y as usize) as f32;
-                    r *= (-dist_to_surface * 0.05).exp();
-                    g *= (-dist_to_surface * 0.045).exp();
-                    b *= (-dist_to_surface * 0.04).exp();
+                    if let Some(cy) = water_cy {
+                        let dist_to_surface = (WATER_H as usize - cy - y as usize) as f32;
+                        r *= (-dist_to_surface * 0.05).exp();
+                        g *= (-dist_to_surface * 0.045).exp();
+                        b *= (-dist_to_surface * 0.04).exp();
+                    }
                 }
                 let vertices = face.vertices_packed(xyz as u32, w as u32, h as u32, lod as u32);
                 let quad_info = (color(r, g, b) << 15) | (layer << 3) | face_n as u32;

--- a/src/render/mesh_logic.rs
+++ b/src/render/mesh_logic.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use bevy::{
     asset::RenderAssetUsages,
     log::info_span,
+    math::Vec3,
     mesh::{Indices, MeshVertexAttribute},
     prelude::Mesh,
     render::render_resource::{PrimitiveTopology, VertexFormat},
@@ -146,5 +147,51 @@ impl Chunk {
         }
         mesh_build_span.exit();
         meshes
+    }
+
+    /// Triangle-mesh collider geometry in chunk-local space, ready to feed to
+    /// `Collider::trimesh`. Returns `None` for fully-traversable chunks.
+    pub fn create_collider_data(&self) -> Option<(Vec<Vec3>, Vec<[u32; 3]>)> {
+        let voxels = self.data.unpack_u16();
+        let mut mesher: bgm::Mesher<CHUNK_S1> = bgm::Mesher::new();
+        let traversable = BTreeSet::from_iter(self.palette.iter().enumerate().filter_map(
+            |(i, block)| {
+                if i != 0 && block.is_traversable() {
+                    Some(i as u16)
+                } else {
+                    None
+                }
+            },
+        ));
+        mesher.mesh(&voxels, &traversable);
+        let mut vertices: Vec<Vec3> = Vec::new();
+        let mut indices: Vec<[u32; 3]> = Vec::new();
+        for (face_n, quads) in mesher.quads.iter().enumerate() {
+            let face: Face = face_n.into();
+            for quad in quads {
+                let voxel_i = quad.voxel_id() as usize;
+                if self.palette[voxel_i].is_traversable() {
+                    continue;
+                }
+                let [x, y, z] = quad.xyz();
+                let w = quad.width();
+                let h = quad.height();
+                let corners = face.vertices_f32(
+                    x as u32, y as u32, z as u32,
+                    w as u32, h as u32, 1,
+                );
+                let base = vertices.len() as u32;
+                vertices.extend_from_slice(&corners);
+                // Per-quad pattern is `bgm::indices`' verbatim, so collider
+                // winding is identical to the render mesh.
+                indices.push([base + 2, base, base + 1]);
+                indices.push([base + 1, base + 3, base + 2]);
+            }
+        }
+        if indices.is_empty() {
+            None
+        } else {
+            Some((vertices, indices))
+        }
     }
 }

--- a/src/render/mesh_thread.rs
+++ b/src/render/mesh_thread.rs
@@ -75,7 +75,7 @@ pub fn setup_mesh_thread(
                 };
                 let chunk_guard = chunk.value().read();
                 let face_meshes =
-                    chunk_guard.create_face_meshes(&texture_map, lod, chunk_pos);
+                    chunk_guard.create_face_meshes(&texture_map, lod, Some(chunk_pos.y));
                 // Colliders only at LOD=1 — distant chunks are outside
                 // physics-active range and would only inflate the trimesh.
                 let collider = if lod == 1 {

--- a/src/render/mesh_thread.rs
+++ b/src/render/mesh_thread.rs
@@ -4,6 +4,7 @@ use crate::logging::LogData;
 use crate::render::mesh_draw::{LOD, choose_lod_level};
 use crate::render::texture_array::TextureMap;
 use crate::world::{ChunkPos, ChunkPos2d, PlayerCol, VoxelWorld};
+use avian3d::prelude::Collider;
 use bevy::prelude::*;
 use bevy::tasks::AsyncComputeTaskPool;
 use crossbeam::channel::{Receiver, Sender, unbounded};
@@ -22,7 +23,9 @@ pub fn setup_mesh_thread(
     let thread_pool = AsyncComputeTaskPool::get();
     let chunks = voxel_world.chunks.clone();
     let (mesh_sender, mesh_reciever) = unbounded();
+    let (collider_sender, collider_reciever) = unbounded();
     commands.insert_resource(MeshReciever(mesh_reciever));
+    commands.insert_resource(ColliderReciever(collider_reciever));
     let texture_map = texture_map.0.clone();
     let mesh_order_receiver = mesh_order_receiver.0.clone();
     let shared_load_area = shared_load_area.0.clone();
@@ -70,12 +73,27 @@ pub fn setup_mesh_thread(
                 let Some(chunk) = chunks.get(&chunk_pos) else {
                     continue;
                 };
+                let chunk_guard = chunk.value().read();
                 let face_meshes =
-                    chunk
-                        .value()
-                        .read()
-                        .create_face_meshes(&texture_map, lod, chunk_pos);
+                    chunk_guard.create_face_meshes(&texture_map, lod, chunk_pos);
+                // Colliders only at LOD=1 — distant chunks are outside
+                // physics-active range and would only inflate the trimesh.
+                let collider = if lod == 1 {
+                    chunk_guard
+                        .create_collider_data()
+                        .map(|(verts, idx)| Collider::trimesh(verts, idx))
+                } else {
+                    None
+                };
+                drop(chunk_guard);
                 trace!("{}", LogData::ChunkMeshed(chunk_pos));
+                if collider_sender
+                    .send((collider, chunk_pos, LOD(lod)))
+                    .is_err()
+                {
+                    warn!("Collider channel is closed, stopping mesh thread");
+                    break 'outer;
+                }
                 for (i, face_mesh) in face_meshes.into_iter().enumerate() {
                     let face = i.into();
                     if mesh_sender
@@ -93,6 +111,9 @@ pub fn setup_mesh_thread(
 
 #[derive(Resource)]
 pub struct MeshReciever(pub Receiver<(Option<Mesh>, ChunkPos, Face, LOD)>);
+
+#[derive(Resource)]
+pub struct ColliderReciever(pub Receiver<(Option<Collider>, ChunkPos, LOD)>);
 
 #[derive(Resource)]
 pub struct MeshOrderSender(pub Sender<ChunkPos>);

--- a/src/render/mesh_utils.rs
+++ b/src/render/mesh_utils.rs
@@ -1,3 +1,4 @@
+use bevy::math::Vec3;
 use crate::block::Face;
 // Note: This whole file will become unnecessary when we have instancing,
 // because it is used to convert a quad to 4 vertices which we won't need to do
@@ -51,6 +52,56 @@ impl Face {
                 vertex_info(xyz-packed_xyz(w_, 0, 0), 0, h),
                 vertex_info(xyz+packed_xyz(0, h_, 0), w, 0),
                 vertex_info(xyz, w, h),
+            ],
+        }
+    }
+
+    /// `Vec3` companion to `vertices_packed` for physics collider geometry.
+    /// Same per-face corner ordering, so `bgm::indices`' winding still applies.
+    pub fn vertices_f32(&self, x: u32, y: u32, z: u32, w: u32, h: u32, lod: u32) -> [Vec3; 4] {
+        let lod = lod as f32;
+        let x = x as f32 * lod;
+        let y = y as f32 * lod;
+        let z = z as f32 * lod;
+        let w = w as f32 * lod;
+        let h = h as f32 * lod;
+        let p = |dx: f32, dy: f32, dz: f32| Vec3::new(x + dx, y + dy, z + dz);
+        match self {
+            Face::Left => [
+                p(0., 0., 0.),
+                p(0., 0., h),
+                p(0., w, 0.),
+                p(0., w, h),
+            ],
+            Face::Down => [
+                p(-w, 0., h),
+                p(-w, 0., 0.),
+                p(0., 0., h),
+                p(0., 0., 0.),
+            ],
+            Face::Back => [
+                p(0., 0., 0.),
+                p(0., h, 0.),
+                p(w, 0., 0.),
+                p(w, h, 0.),
+            ],
+            Face::Right => [
+                p(0., 0., 0.),
+                p(0., 0., h),
+                p(0., -w, 0.),
+                p(0., -w, h),
+            ],
+            Face::Up => [
+                p(w, 0., h),
+                p(w, 0., 0.),
+                p(0., 0., h),
+                p(0., 0., 0.),
+            ],
+            Face::Front => [
+                p(-w, h, 0.),
+                p(-w, 0., 0.),
+                p(0., h, 0.),
+                p(0., 0., 0.),
             ],
         }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -14,8 +14,9 @@ use bevy::prelude::Plugin;
 pub use texture_load::*;
 pub use texture_array::TextureMap;
 pub use camera::{FpsCam, CameraSpawn};
+pub use mesh_draw::ChunkColliderEntities;
 pub use mesh_thread::{MeshOrderReceiver, MeshOrderSender};
-pub use voxel_grid_mesh_draw::spawn_voxel_grid;
+pub use voxel_grid_mesh_draw::{GridChildEntities, spawn_voxel_grid};
 
 pub struct Render;
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6,12 +6,16 @@ mod mesh_utils;
 mod mesh_logic;
 mod texture_load;
 mod texture_array;
+mod voxel_grid_mesh_draw;
+mod voxel_grid_mesh_thread;
 mod sky;
 mod effects;
 use bevy::prelude::Plugin;
 pub use texture_load::*;
+pub use texture_array::TextureMap;
 pub use camera::{FpsCam, CameraSpawn};
 pub use mesh_thread::{MeshOrderReceiver, MeshOrderSender};
+pub use voxel_grid_mesh_draw::spawn_voxel_grid;
 
 pub struct Render;
 
@@ -19,6 +23,7 @@ impl Plugin for Render {
     fn build(&self, app: &mut bevy::prelude::App) {
 		app
 			.add_plugins(mesh_draw::Draw3d)
+			.add_plugins(voxel_grid_mesh_draw::VoxelGridPlugin)
 			.add_plugins(sky::SkyPlugin)
 			.add_plugins(camera::Camera3dPlugin)
 			.add_plugins(effects::EffectsPlugin)

--- a/src/render/voxel_grid_mesh_draw.rs
+++ b/src/render/voxel_grid_mesh_draw.rs
@@ -1,0 +1,154 @@
+use crate::block::Face;
+use crate::render::texture_array::{BlockTextureArray, TextureMap};
+use crate::render::voxel_grid_mesh_thread::{
+    GridColliderOutput, GridMeshOutput, spawn_grid_mesh_thread,
+};
+use crate::world::{CHUNK_S1, GridChunkPos, VoxelGrid};
+use avian3d::prelude::{Collider, Dominance, Friction, RigidBody};
+use bevy::camera::primitives::Aabb;
+use bevy::camera::visibility::NoFrustumCulling;
+use bevy::prelude::*;
+use crossbeam::channel::{Receiver, unbounded};
+use itertools::Itertools;
+use std::collections::HashMap;
+
+use super::BlockTexState;
+
+pub struct VoxelGridPlugin;
+
+impl Plugin for VoxelGridPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (pull_grid_meshes, pull_grid_colliders).run_if(in_state(BlockTexState::Mapped)),
+        );
+    }
+}
+
+#[derive(Component)]
+pub struct GridMeshReceiver(pub Receiver<GridMeshOutput>);
+
+#[derive(Component)]
+pub struct GridColliderReceiver(pub Receiver<GridColliderOutput>);
+
+/// Tracks the visual and collider child entities owned by a `VoxelGrid` root,
+/// keyed by chunk position. Pull systems use it to update or despawn children
+/// when chunk geometry changes.
+#[derive(Component, Default)]
+pub struct GridChildEntities {
+    mesh: HashMap<(GridChunkPos, Face), Entity>,
+    collider: HashMap<GridChunkPos, Entity>,
+}
+
+/// Spawn a movable voxel grid: creates the worker, runs the `build` closure to
+/// fill blocks, spawns the rigidbody root, and queues every populated chunk
+/// for meshing. Must be called while `BlockTexState::Mapped` is active so the
+/// worker captures a populated texture map.
+pub fn spawn_voxel_grid(
+    commands: &mut Commands,
+    texture_map: &TextureMap,
+    transform: Transform,
+    build: impl FnOnce(&mut VoxelGrid),
+) -> Entity {
+    let (order_sender, order_receiver) = unbounded::<GridChunkPos>();
+    let mut grid = VoxelGrid::new(order_sender.clone());
+    build(&mut grid);
+    let chunks = grid.chunks.clone();
+    let (mesh_receiver, collider_receiver) =
+        spawn_grid_mesh_thread(chunks.clone(), texture_map.0.clone(), order_receiver);
+    let entity = commands
+        .spawn((
+            grid,
+            RigidBody::Dynamic,
+            Friction::new(1.0),
+            // Outweigh the player so resting/walking on a grid doesn't push
+            // it around. Grid-vs-grid stays balanced (equal dominance).
+            Dominance(10),
+            transform,
+            Visibility::default(),
+            GridMeshReceiver(mesh_receiver),
+            GridColliderReceiver(collider_receiver),
+            GridChildEntities::default(),
+        ))
+        .id();
+    for entry in chunks.iter() {
+        let _ = order_sender.send(*entry.key());
+    }
+    entity
+}
+
+fn pull_grid_meshes(
+    mut commands: Commands,
+    mut grids: Query<(Entity, &GridMeshReceiver, &mut GridChildEntities)>,
+    mut mesh_query: Query<&mut Mesh3d>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    block_tex_array: Res<BlockTextureArray>,
+) {
+    for (grid_entity, recv, mut tracker) in grids.iter_mut() {
+        // Coalesce duplicates so older geometry is dropped.
+        let received: Vec<_> = recv.0.try_iter().collect();
+        for (mesh_opt, chunk_pos, face) in received
+            .into_iter()
+            .rev()
+            .unique_by(|(_, pos, face)| (*pos, *face))
+        {
+            let key = (chunk_pos, face);
+            let Some(mesh) = mesh_opt else {
+                if let Some(ent) = tracker.mesh.remove(&key) {
+                    commands.entity(ent).despawn();
+                }
+                continue;
+            };
+            if let Some(&ent) = tracker.mesh.get(&key) {
+                if let Ok(mut handle) = mesh_query.get_mut(ent) {
+                    handle.0 = meshes.add(mesh);
+                    continue;
+                }
+            }
+            let chunk_aabb = Aabb::from_min_max(Vec3::ZERO, Vec3::splat(CHUNK_S1 as f32));
+            let child = commands
+                .spawn((
+                    Mesh3d(meshes.add(mesh)),
+                    MeshMaterial3d(block_tex_array.0.clone()),
+                    Transform::from_translation(Vec3::from(chunk_pos)),
+                    NoFrustumCulling,
+                    chunk_aabb,
+                ))
+                .id();
+            commands.entity(grid_entity).add_child(child);
+            tracker.mesh.insert(key, child);
+        }
+    }
+}
+
+fn pull_grid_colliders(
+    mut commands: Commands,
+    mut grids: Query<(Entity, &GridColliderReceiver, &mut GridChildEntities)>,
+    mut collider_query: Query<&mut Collider>,
+) {
+    for (grid_entity, recv, mut tracker) in grids.iter_mut() {
+        let received: Vec<_> = recv.0.try_iter().collect();
+        for (collider_opt, chunk_pos) in received.into_iter().rev().unique_by(|(_, pos)| *pos) {
+            let Some(collider) = collider_opt else {
+                if let Some(ent) = tracker.collider.remove(&chunk_pos) {
+                    commands.entity(ent).despawn();
+                }
+                continue;
+            };
+            if let Some(&ent) = tracker.collider.get(&chunk_pos) {
+                if let Ok(mut handle) = collider_query.get_mut(ent) {
+                    *handle = collider;
+                    continue;
+                }
+            }
+            let child = commands
+                .spawn((
+                    collider,
+                    Transform::from_translation(Vec3::from(chunk_pos)),
+                ))
+                .id();
+            commands.entity(grid_entity).add_child(child);
+            tracker.collider.insert(chunk_pos, child);
+        }
+    }
+}

--- a/src/render/voxel_grid_mesh_draw.rs
+++ b/src/render/voxel_grid_mesh_draw.rs
@@ -3,13 +3,15 @@ use crate::render::texture_array::{BlockTextureArray, TextureMap};
 use crate::render::voxel_grid_mesh_thread::{
     GridColliderOutput, GridMeshOutput, spawn_grid_mesh_thread,
 };
-use crate::world::{CHUNK_S1, GridChunkPos, VoxelGrid};
-use avian3d::prelude::{Collider, Dominance, Friction, RigidBody};
+use crate::world::{CHUNK_S1, Chunk, GridChunkPos, VoxelGrid};
+use avian3d::prelude::{CenterOfMass, Collider, Dominance, Friction, Mass, RigidBody};
 use bevy::camera::primitives::Aabb;
 use bevy::camera::visibility::NoFrustumCulling;
 use bevy::prelude::*;
 use crossbeam::channel::{Receiver, unbounded};
+use crossbeam_skiplist::SkipMap;
 use itertools::Itertools;
+use parking_lot::RwLock;
 use std::collections::HashMap;
 
 use super::BlockTexState;
@@ -36,14 +38,20 @@ pub struct GridColliderReceiver(pub Receiver<GridColliderOutput>);
 /// when chunk geometry changes.
 #[derive(Component, Default)]
 pub struct GridChildEntities {
-    mesh: HashMap<(GridChunkPos, Face), Entity>,
-    collider: HashMap<GridChunkPos, Entity>,
+    pub(crate) mesh: HashMap<(GridChunkPos, Face), Entity>,
+    pub collider: HashMap<GridChunkPos, Entity>,
 }
 
 /// Spawn a movable voxel grid: creates the worker, runs the `build` closure to
 /// fill blocks, spawns the rigidbody root, and queues every populated chunk
 /// for meshing. Must be called while `BlockTexState::Mapped` is active so the
 /// worker captures a populated texture map.
+///
+/// Colliders for the initial chunks are computed *synchronously* and attached
+/// as children at spawn time. This keeps Avian from seeing a `RigidBody::Dynamic`
+/// with an empty compound (which produces a "no mass" warning and can NaN
+/// the whole physics step). Visual meshes are still computed asynchronously by
+/// the worker — they appear a frame or two later, which is fine.
 pub fn spawn_voxel_grid(
     commands: &mut Commands,
     texture_map: &TextureMap,
@@ -54,23 +62,61 @@ pub fn spawn_voxel_grid(
     let mut grid = VoxelGrid::new(order_sender.clone());
     build(&mut grid);
     let chunks = grid.chunks.clone();
+
+    // Padding stays default-zero (no neighbour sync). Each chunk's trimesh
+    // therefore emits faces on every chunk boundary, making it a *closed
+    // manifold* of its own block contents — required by Parry's
+    // `mass_properties` to produce a sane volume. The visual cost is
+    // duplicate seam surfaces between adjacent grid chunks; sibling
+    // colliders of the same compound don't self-collide, so this is purely
+    // cosmetic (z-fighting at seams on multi-chunk grids only).
+    let initial_colliders: Vec<(GridChunkPos, Collider)> = chunks
+        .iter()
+        .filter_map(|entry| {
+            let chunk_pos = *entry.key();
+            let guard = entry.value().read();
+            guard
+                .create_collider_data()
+                .map(|(verts, idx)| (chunk_pos, Collider::trimesh(verts, idx)))
+        })
+        .collect();
+
+    // Mass + COM from per-block density. Overrides Avian's default
+    // (collider-volume × default density), which would treat a stone block
+    // and a leaf block as equally heavy.
+    let (mass, com) = compute_mass_properties(&chunks);
+
     let (mesh_receiver, collider_receiver) =
         spawn_grid_mesh_thread(chunks.clone(), texture_map.0.clone(), order_receiver);
+
     let entity = commands
         .spawn((
             grid,
             RigidBody::Dynamic,
             Friction::new(1.0),
-            // Outweigh the player so resting/walking on a grid doesn't push
-            // it around. Grid-vs-grid stays balanced (equal dominance).
             Dominance(10),
+            Mass(mass),
+            CenterOfMass(com),
             transform,
             Visibility::default(),
             GridMeshReceiver(mesh_receiver),
             GridColliderReceiver(collider_receiver),
-            GridChildEntities::default(),
         ))
         .id();
+
+    let mut tracker = GridChildEntities::default();
+    for (chunk_pos, collider) in initial_colliders {
+        let child = commands
+            .spawn((
+                collider,
+                Transform::from_translation(Vec3::from(chunk_pos)),
+            ))
+            .id();
+        commands.entity(entity).add_child(child);
+        tracker.collider.insert(chunk_pos, child);
+    }
+    commands.entity(entity).insert(tracker);
+
     for entry in chunks.iter() {
         let _ = order_sender.send(*entry.key());
     }
@@ -152,3 +198,41 @@ fn pull_grid_colliders(
         }
     }
 }
+
+/// Walk every populated cell of every chunk, summing density and the
+/// density-weighted position. Returns `(mass, centre_of_mass)` in the grid's
+/// body-local frame. Centre of mass is `Vec3::ZERO` for an all-air grid;
+/// callers should fall back gracefully (Avian only uses CoM if mass > 0).
+fn compute_mass_properties(
+    chunks: &SkipMap<GridChunkPos, RwLock<Chunk>>,
+) -> (f32, Vec3) {
+    let mut total_mass: f32 = 0.0;
+    let mut moment: Vec3 = Vec3::ZERO;
+    for entry in chunks.iter() {
+        let chunk_pos = *entry.key();
+        let chunk_origin = Vec3::from(chunk_pos);
+        let guard = entry.value().read();
+        for x in 0..CHUNK_S1 {
+            for y in 0..CHUNK_S1 {
+                for z in 0..CHUNK_S1 {
+                    let block = guard.get(crate::world::ChunkedPos { x, y, z });
+                    let d = block.density();
+                    if d <= 0.0 {
+                        continue;
+                    }
+                    let cell_centre = chunk_origin
+                        + Vec3::new(x as f32 + 0.5, y as f32 + 0.5, z as f32 + 0.5);
+                    total_mass += d;
+                    moment += cell_centre * d;
+                }
+            }
+        }
+    }
+    let com = if total_mass > 0.0 {
+        moment / total_mass
+    } else {
+        Vec3::ZERO
+    };
+    (total_mass, com)
+}
+

--- a/src/render/voxel_grid_mesh_thread.rs
+++ b/src/render/voxel_grid_mesh_thread.rs
@@ -3,12 +3,12 @@ use crate::block::{Face, FaceSpecifier};
 use crate::world::{Chunk, GridChunkPos};
 use avian3d::prelude::Collider;
 use bevy::prelude::Mesh;
-use bevy::tasks::AsyncComputeTaskPool;
 use crossbeam::channel::{Receiver, unbounded};
 use crossbeam_skiplist::SkipMap;
 use hashbrown::HashMap;
 use parking_lot::RwLock;
 use std::sync::Arc;
+use std::thread;
 
 pub type GridMeshOutput = (Option<Mesh>, GridChunkPos, Face);
 pub type GridColliderOutput = (Option<Collider>, GridChunkPos);
@@ -27,28 +27,29 @@ pub fn spawn_grid_mesh_thread(
 ) -> (Receiver<GridMeshOutput>, Receiver<GridColliderOutput>) {
     let (mesh_sender, mesh_receiver) = unbounded::<GridMeshOutput>();
     let (collider_sender, collider_receiver) = unbounded::<GridColliderOutput>();
-    AsyncComputeTaskPool::get()
-        .spawn(async move {
-            while let Ok(chunk_pos) = orders.recv() {
-                let Some(entry) = chunks.get(&chunk_pos) else {
-                    continue;
-                };
-                let chunk_guard = entry.value().read();
-                let face_meshes = chunk_guard.create_face_meshes(&texture_map, 1, None);
-                let collider = chunk_guard
-                    .create_collider_data()
-                    .map(|(verts, idx)| Collider::trimesh(verts, idx));
-                drop(chunk_guard);
-                if collider_sender.send((collider, chunk_pos)).is_err() {
+    // Use std::thread::spawn rather than AsyncComputeTaskPool: each grid
+    // gets its own OS thread that blocks on `orders.recv()` without
+    // competing with other Bevy/Avian work for the shared task-pool threads.
+    thread::spawn(move || {
+        while let Ok(chunk_pos) = orders.recv() {
+            let Some(entry) = chunks.get(&chunk_pos) else {
+                continue;
+            };
+            let chunk_guard = entry.value().read();
+            let face_meshes = chunk_guard.create_face_meshes(&texture_map, 1, None);
+            let collider = chunk_guard
+                .create_collider_data()
+                .map(|(verts, idx)| Collider::trimesh(verts, idx));
+            drop(chunk_guard);
+            if collider_sender.send((collider, chunk_pos)).is_err() {
+                return;
+            }
+            for (face_n, mesh) in face_meshes.into_iter().enumerate() {
+                if mesh_sender.send((mesh, chunk_pos, face_n.into())).is_err() {
                     return;
                 }
-                for (face_n, mesh) in face_meshes.into_iter().enumerate() {
-                    if mesh_sender.send((mesh, chunk_pos, face_n.into())).is_err() {
-                        return;
-                    }
-                }
             }
-        })
-        .detach();
+        }
+    });
     (mesh_receiver, collider_receiver)
 }

--- a/src/render/voxel_grid_mesh_thread.rs
+++ b/src/render/voxel_grid_mesh_thread.rs
@@ -1,0 +1,54 @@
+use crate::Block;
+use crate::block::{Face, FaceSpecifier};
+use crate::world::{Chunk, GridChunkPos};
+use avian3d::prelude::Collider;
+use bevy::prelude::Mesh;
+use bevy::tasks::AsyncComputeTaskPool;
+use crossbeam::channel::{Receiver, unbounded};
+use crossbeam_skiplist::SkipMap;
+use hashbrown::HashMap;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+pub type GridMeshOutput = (Option<Mesh>, GridChunkPos, Face);
+pub type GridColliderOutput = (Option<Collider>, GridChunkPos);
+
+/// Spawns a detached worker that meshes chunks of one voxel grid. The worker
+/// drains `orders` and produces (per chunk) six face meshes plus one trimesh
+/// collider, sending them on the returned receivers.
+///
+/// The texture map is cloned into the worker. Callers must therefore only
+/// invoke this once `BlockTexState::Mapped` has been entered, otherwise the
+/// worker captures an empty map and emits untextured meshes forever.
+pub fn spawn_grid_mesh_thread(
+    chunks: Arc<SkipMap<GridChunkPos, RwLock<Chunk>>>,
+    texture_map: HashMap<(Block, FaceSpecifier), usize>,
+    orders: Receiver<GridChunkPos>,
+) -> (Receiver<GridMeshOutput>, Receiver<GridColliderOutput>) {
+    let (mesh_sender, mesh_receiver) = unbounded::<GridMeshOutput>();
+    let (collider_sender, collider_receiver) = unbounded::<GridColliderOutput>();
+    AsyncComputeTaskPool::get()
+        .spawn(async move {
+            while let Ok(chunk_pos) = orders.recv() {
+                let Some(entry) = chunks.get(&chunk_pos) else {
+                    continue;
+                };
+                let chunk_guard = entry.value().read();
+                let face_meshes = chunk_guard.create_face_meshes(&texture_map, 1, None);
+                let collider = chunk_guard
+                    .create_collider_data()
+                    .map(|(verts, idx)| Collider::trimesh(verts, idx));
+                drop(chunk_guard);
+                if collider_sender.send((collider, chunk_pos)).is_err() {
+                    return;
+                }
+                for (face_n, mesh) in face_meshes.into_iter().enumerate() {
+                    if mesh_sender.send((mesh, chunk_pos, face_n.into())).is_err() {
+                        return;
+                    }
+                }
+            }
+        })
+        .detach();
+    (mesh_receiver, collider_receiver)
+}

--- a/src/sounds/block_sounds.rs
+++ b/src/sounds/block_sounds.rs
@@ -1,5 +1,6 @@
 use super::block_sound_load::{BlockSound, BlockSoundLoadPlugin, BlockSounds};
-use crate::agents::{BlockActionType, BlockLootAction, SteppingOn};
+use crate::agents::{BlockActionType, BlockLootAction, LootTarget, SteppingOn};
+use crate::world::VoxelGrid;
 use avian3d::prelude::LinearVelocity;
 use bevy::{
     audio::{PlaybackMode, SpatialScale},
@@ -65,6 +66,7 @@ fn breaking(
     block_sounds: Res<BlockSounds>,
     time: Res<Time>,
     mut looting_query: Query<(&BlockLootAction, &mut BlockSoundCD)>,
+    grids: Query<&GlobalTransform, With<VoxelGrid>>,
 ) {
     for (looting_action, mut sound_cd) in looting_query.iter_mut() {
         sound_cd.0 -= time.delta_secs();
@@ -80,9 +82,16 @@ fn breaking(
         ) else {
             continue;
         };
+        let world_pos = match &looting_action.target {
+            LootTarget::World(pos) => Vec3::from(*pos),
+            LootTarget::Grid { grid, pos } => {
+                let Ok(xform) = grids.get(*grid) else { continue };
+                xform.transform_point(Vec3::new(pos.x as f32, pos.y as f32, pos.z as f32))
+            }
+        };
         commands
             .spawn((
-                Transform::from_translation(looting_action.block_pos.into()),
+                Transform::from_translation(world_pos),
                 Visibility::default(),
             ))
             .insert((

--- a/src/sounds/block_sounds.rs
+++ b/src/sounds/block_sounds.rs
@@ -1,5 +1,6 @@
 use super::block_sound_load::{BlockSound, BlockSoundLoadPlugin, BlockSounds};
-use crate::agents::{BlockActionType, BlockLootAction, SteppingOn, Velocity};
+use crate::agents::{BlockActionType, BlockLootAction, SteppingOn};
+use avian3d::prelude::LinearVelocity;
 use bevy::{
     audio::{PlaybackMode, SpatialScale},
     prelude::*,
@@ -26,7 +27,7 @@ fn footsteps(
     mut commands: Commands,
     block_sounds: Res<BlockSounds>,
     time: Res<Time>,
-    mut steppers_query: Query<(&Transform, &Velocity, &SteppingOn, &mut FootstepCD)>,
+    mut steppers_query: Query<(&Transform, &LinearVelocity, &SteppingOn, &mut FootstepCD)>,
 ) {
     for (transform, velocity, stepping_on, mut footstep_cd) in steppers_query.iter_mut() {
         let speed = velocity.0.length();

--- a/src/ui/debug_display.rs
+++ b/src/ui/debug_display.rs
@@ -1,6 +1,6 @@
 use crate::Block;
-use crate::agents::{PlayerControlled, TargetBlock};
-use crate::world::VoxelWorld;
+use crate::agents::{PlayerControlled, TargetBlock, TargetKind};
+use crate::world::{VoxelGrid, VoxelWorld};
 use bevy::color::palettes::css;
 use bevy::diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin};
 use bevy::prelude::*;
@@ -104,12 +104,16 @@ fn update_block_display(
     player_query: Query<&TargetBlock, With<PlayerControlled>>,
     mut block_text_query: Query<&mut Text, With<DebugTextBlock>>,
     world: Res<VoxelWorld>,
+    grids: Query<&VoxelGrid>,
 ) {
     let target_block = player_query.single().unwrap();
-    let block = if let Some(raycast_hit) = &target_block.0 {
-        world.get_block_safe(raycast_hit.pos)
-    } else {
-        Block::Air
+    let block = match &target_block.0 {
+        Some(TargetKind::World(hit)) => world.get_block_safe(hit.pos),
+        Some(TargetKind::Grid { grid, pos, .. }) => grids
+            .get(*grid)
+            .map(|g| g.get_block(*pos))
+            .unwrap_or(Block::Air),
+        None => Block::Air,
     };
     if let Ok(mut block_text) = block_text_query.single_mut() {
         block_text.0 = format!("block: {block:?}\n");

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -5,6 +5,7 @@ mod pos;
 mod realm;
 mod terrain_thread;
 mod utils;
+mod voxel_grid;
 mod voxel_world;
 use crate::world::{
     block_entities::unload_block_entities,
@@ -15,6 +16,7 @@ pub use block_entities::BlockEntities;
 pub use chunk::*;
 pub use pos::*;
 pub use realm::*;
+pub use voxel_grid::*;
 pub use voxel_world::*;
 pub const CHUNK_S1: usize = 62;
 pub const REGION_S1: usize = CHUNK_S1 * 16;

--- a/src/world/voxel_grid.rs
+++ b/src/world/voxel_grid.rs
@@ -1,0 +1,91 @@
+use crate::Block;
+use crate::world::{CHUNK_S1, Chunk, ChunkedPos, chunked};
+use bevy::prelude::*;
+use crossbeam::channel::Sender;
+use crossbeam_skiplist::SkipMap;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+/// Block coordinate inside a voxel grid's local frame. Mirrors `BlockPos` but
+/// drops `Realm` — each grid is its own coordinate system, anchored to the
+/// owning entity's `Transform.translation`.
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]
+pub struct GridBlockPos {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+/// Chunk coordinate inside a voxel grid. Stride is `CHUNK_S1`, same as the
+/// world's `ChunkPos`.
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct GridChunkPos {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+impl From<GridBlockPos> for (GridChunkPos, ChunkedPos) {
+    fn from(p: GridBlockPos) -> Self {
+        let (cx, dx) = chunked::<CHUNK_S1, 1>(p.x);
+        let (cy, dy) = chunked::<CHUNK_S1, 1>(p.y);
+        let (cz, dz) = chunked::<CHUNK_S1, 1>(p.z);
+        (
+            GridChunkPos {
+                x: cx,
+                y: cy,
+                z: cz,
+            },
+            ChunkedPos {
+                x: dx,
+                y: dy,
+                z: dz,
+            },
+        )
+    }
+}
+
+impl From<GridChunkPos> for Vec3 {
+    fn from(p: GridChunkPos) -> Self {
+        Vec3::new(p.x as f32, p.y as f32, p.z as f32) * CHUNK_S1 as f32
+    }
+}
+
+/// Voxel data for a movable rigidbody grid. Lives as a `Component` on the
+/// grid's root entity. Storage layout mirrors `VoxelWorld`: a thread-safe
+/// skiplist of chunks behind an `Arc`, plus a sender that signals which chunks
+/// need re-meshing.
+#[derive(Component, Clone)]
+pub struct VoxelGrid {
+    pub chunks: Arc<SkipMap<GridChunkPos, RwLock<Chunk>>>,
+    pub(crate) chunk_changes: Sender<GridChunkPos>,
+}
+
+impl VoxelGrid {
+    pub fn new(chunk_changes: Sender<GridChunkPos>) -> Self {
+        Self {
+            chunks: Arc::new(SkipMap::new()),
+            chunk_changes,
+        }
+    }
+
+    pub fn set_block(&self, pos: GridBlockPos, block: Block) {
+        let (chunk_pos, chunked_pos) = <(GridChunkPos, ChunkedPos)>::from(pos);
+        self.chunks
+            .get_or_insert_with(chunk_pos, || RwLock::new(Chunk::new()))
+            .value()
+            .write()
+            .set(chunked_pos, block);
+        // The receiver lives on the per-grid mesh worker; if it's been dropped
+        // (grid despawned mid-build), the order is silently discarded.
+        let _ = self.chunk_changes.send(chunk_pos);
+    }
+
+    pub fn get_block(&self, pos: GridBlockPos) -> Block {
+        let (chunk_pos, chunked_pos) = <(GridChunkPos, ChunkedPos)>::from(pos);
+        match self.chunks.get(&chunk_pos) {
+            Some(entry) => entry.value().read().get(chunked_pos).clone(),
+            None => Block::Air,
+        }
+    }
+}

--- a/src/world/voxel_world.rs
+++ b/src/world/voxel_world.rs
@@ -13,6 +13,7 @@ use crossbeam_skiplist::{SkipMap, map::Entry};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
+#[derive(Debug, Clone)]
 pub struct BlockRayCastHit {
     pub pos: BlockPos,
     pub normal: Vec3,

--- a/src/world/voxel_world.rs
+++ b/src/world/voxel_world.rs
@@ -306,6 +306,14 @@ impl VoxelWorld {
             y: start.y.floor() as i32,
             z: start.z.floor() as i32,
         };
+        // Test the starting cell before stepping — otherwise a ray that begins
+        // inside a solid block would skip it.
+        if self.get_block_safe(pos).is_targetable() {
+            return Some(BlockRayCastHit {
+                pos,
+                normal: Vec3::ZERO,
+            });
+        }
         let mut last_pos;
         let sx = dir.x.signum() as i32;
         let sy = dir.y.signum() as i32;


### PR DESCRIPTION
This adds voxel grids as separate bodies in the world. Avian physics replaces the voxel test collision system, with mesh colliders for the world and separate grids. Isolated groups of blocks split into a separate grid.

These changes would be the foundation for vehicles, which would need control and propulsion type blocks. For now, they work to model things like felling trees and collapsing structures. A smarter decomposition of grids into convex colliders to avoid mesh-mesh collision detection might eventually make sense, but for reasonably small grids this approach seems fast enough.

Grids in unloaded chunks are not currently handled.