### PR TITLE
Add mipmaps

### DIFF
--- a/crates/rb_render/src/texture_array.rs
+++ b/crates/rb_render/src/texture_array.rs
@@ -176,7 +176,6 @@ fn resize_image(image: &Image, size: u32) -> Image {
 }
 
 // Takes a full resolution image texture as a base and generates a chain of downsampled versions
-// Returned as one full image with mip level set
 fn build_mip_chain(base: &Image, target_size: u32) -> (Vec<Vec<u8>>, u32) {
     let frame_size = base.width();
     assert_eq!(

--- a/crates/rb_render/src/texture_array.rs
+++ b/crates/rb_render/src/texture_array.rs
@@ -8,7 +8,9 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        render_resource::{AsBindGroup, Extent3d, TextureDimension, TextureFormat},
+        render_resource::{
+            AsBindGroup, Extent3d, TextureDataOrder, TextureDimension, TextureFormat,
+        },
         storage::ShaderBuffer,
     },
     shader::ShaderRef,
@@ -75,6 +77,122 @@ fn missing_tex(model: &Image) -> Image {
     img
 }
 
+fn downsample_image_by_half(image: &Image) -> Image {
+    let width = image.width();
+    let height = image.height();
+
+    if width == 1 && height == 1 {
+        return image.clone();
+    }
+
+    let new_width = (width / 2).max(1);
+    let new_height = (height / 2).max(1);
+    let source = image.data.as_ref().expect("Image has no pixel data");
+    let mut pixels = vec![0u8; (new_width * new_height * 4) as usize];
+
+    for y in 0..new_height {
+        for x in 0..new_width {
+            let mut sum = [0u32; 4];
+            let mut count = 0u32;
+
+            let start_x = x * width / new_width;
+            let end_x = (x + 1) * width / new_width;
+            let start_y = y * height / new_height;
+            let end_y = (y + 1) * height / new_height;
+
+            for source_y in start_y..end_y {
+                for source_x in start_x..end_x {
+                    let source_index = ((source_y * width + source_x) * 4) as usize;
+
+                    for channel in 0..4 {
+                        sum[channel] += source[source_index + channel] as u32;
+                    }
+
+                    count += 1;
+                }
+            }
+
+            let destination_index = ((y * new_width + x) * 4) as usize;
+
+            for channel in 0..4 {
+                pixels[destination_index + channel] = (sum[channel] / count) as u8;
+            }
+        }
+    }
+
+    let mut downsampled = image.clone();
+    downsampled.texture_descriptor.size.width = new_width;
+    downsampled.texture_descriptor.size.height = new_height;
+    downsampled.data = Some(pixels);
+
+    downsampled
+}
+
+fn resize_image(image: &Image, size: u32) -> Image {
+    if image.width() == size && image.height() == size {
+        return image.clone();
+    }
+
+    let source = image.data.as_ref().expect("Image has no pixel data");
+    let mut pixels = vec![0u8; (size * size * 4) as usize];
+    for y in 0..size {
+        for x in 0..size {
+            let source_x = x * image.width() / size;
+            let source_y = y * image.height() / size;
+            let source_index = ((source_y * image.width() + source_x) * 4) as usize;
+            let destination_index = ((y * size + x) * 4) as usize;
+            pixels[destination_index..destination_index + 4]
+                .copy_from_slice(&source[source_index..source_index + 4]);
+        }
+    }
+
+    let mut resized = image.clone();
+    resized.texture_descriptor.size.width = size;
+    resized.texture_descriptor.size.height = size;
+    resized.data = Some(pixels);
+    resized
+}
+
+// Takes a full resolution image texture as a base and generates a chain of downsampled versions
+// Returned as one full image with mip level set
+fn build_mip_chain(base: &Image, target_size: u32) -> (Vec<Vec<u8>>, u32) {
+    let frame_size = base.width();
+    assert_eq!(
+        base.height() % frame_size,
+        0,
+        "Texture height must be a multiple of its width"
+    );
+
+    let source = base.data.as_ref().expect("Image has no pixel data");
+    let bytes_per_frame = (frame_size * frame_size * 4) as usize;
+    let mut frames: Vec<Image> = source
+        .chunks_exact(bytes_per_frame)
+        .map(|pixels| {
+            let mut frame = base.clone();
+            frame.texture_descriptor.size.height = frame_size;
+            frame.data = Some(pixels.to_vec());
+            frame
+        })
+        .map(|frame| resize_image(&frame, target_size))
+        .collect();
+    let mip_level_count = target_size.ilog2() + 1;
+    let mut levels = Vec::with_capacity(mip_level_count as usize);
+
+    for level in 0..mip_level_count {
+        levels.push(
+            frames
+                .iter()
+                .flat_map(|frame| frame.data.as_ref().unwrap().iter().copied())
+                .collect(),
+        );
+        if level + 1 < mip_level_count {
+            frames = frames.iter().map(downsample_image_by_half).collect();
+        }
+    }
+
+    (levels, mip_level_count)
+}
+
 fn build_tex_array(
     mut commands: Commands,
     block_textures: Res<BlockTextureFolder>,
@@ -104,8 +222,10 @@ fn build_tex_array(
             continue;
         };
         let frames = texture.height() / texture.width();
+
         texture_map.0.insert((block, face_specifier), index);
         texture_list.push(texture);
+
         if block == Block::SeaBlock {
             water_layer = Some(index);
         }
@@ -125,23 +245,41 @@ fn build_tex_array(
         TextureFormat::Rgba8Unorm,
         RenderAssetUsages::default(),
     );
-    let model = texture_list.get(0).cloned().unwrap_or(&default);
+    let model = texture_list
+        .iter()
+        .copied()
+        .max_by_key(|texture| texture.width())
+        .unwrap_or(&default);
+    let texture_size = model.width();
     let missing_tex = missing_tex(model);
     texture_list.insert(0, &missing_tex);
-    let array_tex = Image::new(
+
+    let mip_chains: Vec<_> = texture_list
+        .iter()
+        .map(|texture| build_mip_chain(texture, texture_size))
+        .collect();
+    let mip_level_count = mip_chains[0].1;
+    let data = (0..mip_level_count as usize)
+        .flat_map(|level| {
+            mip_chains
+                .iter()
+                .flat_map(move |(levels, _)| levels[level].iter().copied())
+        })
+        .collect();
+
+    let mut array_tex = Image::new_uninit(
         Extent3d {
-            width: model.width(),
-            height: model.height(),
+            width: texture_size,
+            height: texture_size,
             depth_or_array_layers: index as u32,
         },
         TextureDimension::D2,
-        texture_list
-            .into_iter()
-            .flat_map(|tex| tex.data.clone().unwrap())
-            .collect(),
         model.texture_descriptor.format,
         RenderAssetUsages::default(),
     );
+    array_tex.data_order = TextureDataOrder::MipMajor;
+    array_tex.data = Some(data);
+    array_tex.texture_descriptor.mip_level_count = mip_level_count;
     let handle = textures.add(array_tex);
     let handle = materials.add(ExtendedMaterial {
         base: StandardMaterial {

--- a/crates/rb_render/src/texture_array.rs
+++ b/crates/rb_render/src/texture_array.rs
@@ -92,7 +92,8 @@ fn downsample_image_by_half(image: &Image) -> Image {
 
     for y in 0..new_height {
         for x in 0..new_width {
-            let mut sum = [0u32; 4];
+            let mut premultiplied_rgb = [0.0; 3];
+            let mut alpha_sum = 0.0;
             let mut count = 0u32;
 
             let start_x = x * width / new_width;
@@ -103,20 +104,41 @@ fn downsample_image_by_half(image: &Image) -> Image {
             for source_y in start_y..end_y {
                 for source_x in start_x..end_x {
                     let source_index = ((source_y * width + source_x) * 4) as usize;
+                    let alpha = source[source_index + 3] as f32 / 255.0;
 
-                    for channel in 0..4 {
-                        sum[channel] += source[source_index + channel] as u32;
+                    for channel in 0..3 {
+                        let encoded = source[source_index + channel] as f32 / 255.0;
+                        let linear = if image.texture_descriptor.format.is_srgb() {
+                            Srgba::gamma_function(encoded)
+                        } else {
+                            encoded
+                        };
+                        premultiplied_rgb[channel] += linear * alpha;
                     }
 
+                    alpha_sum += alpha;
                     count += 1;
                 }
             }
 
             let destination_index = ((y * new_width + x) * 4) as usize;
+            let alpha = alpha_sum / count as f32;
 
-            for channel in 0..4 {
-                pixels[destination_index + channel] = (sum[channel] / count) as u8;
+            for channel in 0..3 {
+                let linear = if alpha_sum > 0.0 {
+                    premultiplied_rgb[channel] / alpha_sum
+                } else {
+                    0.0
+                };
+                let encoded = if image.texture_descriptor.format.is_srgb() {
+                    Srgba::gamma_function_inverse(linear)
+                } else {
+                    linear
+                };
+                pixels[destination_index + channel] =
+                    (encoded.clamp(0.0, 1.0) * 255.0).round() as u8;
             }
+            pixels[destination_index + 3] = (alpha * 255.0).round() as u8;
         }
     }
 


### PR DESCRIPTION
Hey! This implements basic mipmapping as requested in issue #7.

<img width="499" height="499" alt="Sexy Always Sunny GIF by It&#39;s Always Sunny in Philadelphia" src="https://github.com/user-attachments/assets/5cd69efd-403e-4d2b-8fb0-84bbe80ccec6" />

\
This is a typical game feature obviously so it was really just a matter of adapting and integrating some standard pieces of code. There's simple Bevy/wgpu support for actually using them at runtime, we just need to have the CPU generate each resolution and place them in `texture_array` in the expected positions during setup.

---
So the basic breakdown is 3 very typical functions:
`resize_image` - ensures every texture is aligned with whichever one is largest (I think they're all the same atm but it's a bit of future-proofing)
`downsample_image_by_half` - used repeatedly to get the next smaller version of the texture
`build_mip_chain` - calls both of those and builds them together

Then there's a small modification in the calling function to insert these mipmaps and set some flags for the GPU.

---
**Before:**
<img width="1039" height="373" alt="original" src="https://github.com/user-attachments/assets/c2965a46-2e1e-4627-bd52-a652201a9acf" />
**After:**
<img width="1039" height="373" alt="mipmapped" src="https://github.com/user-attachments/assets/b514149a-1540-4c7d-bf97-f205e11e2de8" />